### PR TITLE
FSJ & Afrika Korps revision

### DIFF
--- a/Afrika Korps (Revised).cat
+++ b/Afrika Korps (Revised).cat
@@ -1,0 +1,3300 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<catalogue id="5469-bf93-f6de-82a4" name="Afrika Korps (Revised)" revision="7" battleScribeVersion="2.03" authorName="Ulf Bernestedt, UrsinePatriarch" authorContact="battlescribe@bernestedt.se, Discord: zharrpostingghoroth" library="false" gameSystemId="976a-b687-1fdb-07ef" gameSystemRevision="25" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+  <profileTypes>
+    <profileType id="94ea-9234-fbd5-3352" name="Command Card [Abridged]">
+      <characteristicTypes>
+        <characteristicType id="1944-fd09-973e-5731" name="Details"/>
+      </characteristicTypes>
+    </profileType>
+  </profileTypes>
+  <entryLinks>
+    <entryLink id="dea9-0183-003c-bd1a" name="Afrika Rifle Company" hidden="false" collective="false" import="true" targetId="8195-e8fe-d94d-0863" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="be7c-1c39-dcb0-f878" name="New CategoryLink" hidden="false" targetId="5630-abd3-15d8-5cc6" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="55c7-84f0-094e-4c6f" name="[F] Panzer III Tank Company" hidden="false" collective="false" import="true" targetId="912e-3dba-2ff4-ab44" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="4892-2776-f68a-e871" name="New CategoryLink" hidden="false" targetId="5630-abd3-15d8-5cc6" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="54f7-831e-41b9-605f" name="[F] Armoured Car Company" hidden="false" collective="false" import="true" targetId="879a-0b04-2062-775f" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="8e4e-4a0c-46a4-690e" name="New CategoryLink" hidden="false" targetId="5630-abd3-15d8-5cc6" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="b14f-d6c8-c427-3631" name="[F] Panzer IV Tank Company" hidden="false" collective="false" import="true" targetId="0954-86f2-0fca-c5fa" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="e68d-b4ea-2150-34b2" name="New CategoryLink" hidden="false" targetId="5630-abd3-15d8-5cc6" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="7848-d075-d62c-7189" name="10.5cm Gun or 15cm Armoured Artillery Battery" hidden="false" collective="false" import="true" targetId="87af-5a4a-1acd-f842" type="selectionEntry">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="08b8-bf94-b23b-218f" type="max"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink id="0021-48c9-5366-9029" name="New CategoryLink" hidden="false" targetId="9be3-4dab-91f0-f7c5" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="659d-48d4-95da-4c4a" name="Afrika Rifle Platoon" hidden="true" collective="false" import="true" targetId="a3e3-a0a5-b1cb-155c" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8195-e8fe-d94d-0863" type="greaterThan"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="5127-7f35-cf3d-c360" name="New CategoryLink" hidden="false" targetId="b531-2fd7-ec0e-d214" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="85fc-5d59-2b4b-bf0b" name="[SC] Marder, Marder II, or Diana" hidden="false" collective="false" import="true" targetId="3d6b-4912-00bd-0da6" type="selectionEntry">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1fc9-8ea5-d2fd-639d" type="max"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink id="4a50-1e58-853a-b79b" name="New CategoryLink" hidden="false" targetId="9be3-4dab-91f0-f7c5" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="846d-4210-7f14-2878" name="[P] Panzer IV Tank Platoon" hidden="true" collective="false" import="true" targetId="2fe8-236b-99f4-44ce" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0954-86f2-0fca-c5fa" type="greaterThan"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="e380-386c-ff2d-6594" name="New CategoryLink" hidden="false" targetId="b531-2fd7-ec0e-d214" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="ba00-9462-903d-2176" name="Panzer III Tank Platoon (5cm)" hidden="true" collective="false" import="true" targetId="9892-987c-62b9-08c8" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="912e-3dba-2ff4-ab44" type="greaterThan"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="3ec1-b8a7-f73a-0c63" name="New CategoryLink" hidden="false" targetId="b531-2fd7-ec0e-d214" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="0302-46b7-2ea6-8f5e" name="Ju 87 Stuka Dive Bomber Flight" hidden="false" collective="false" import="true" targetId="de9e-eba7-2d35-9d81" type="selectionEntry">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="14f3-42da-6214-db13" type="max"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink id="f3b9-e90a-a3d3-2b40" name="New CategoryLink" hidden="false" targetId="9be3-4dab-91f0-f7c5" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="75ce-4a8b-f5ef-c1cf" name="Reconnaissance Support Unit" hidden="false" collective="false" import="true" targetId="5275-a14c-ea45-9444" type="selectionEntry">
+      <constraints>
+        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0311-35ac-c7b6-bebd" type="max"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink id="b41a-998a-85bd-e240" name="New CategoryLink" hidden="false" targetId="9be3-4dab-91f0-f7c5" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="f40c-6bb5-a757-5f3b" name="SUPPORT] Tiger Tank or Diana Tank-Hunter Platoon" hidden="false" collective="false" import="true" targetId="4a4d-6e94-b13e-dcec" type="selectionEntry">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3f55-2a56-587a-f5eb" type="max"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink id="5c43-d465-87f3-242b" name="New CategoryLink" hidden="false" targetId="9be3-4dab-91f0-f7c5" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="87f3-67bc-84c4-de9b" name="Command Cards" hidden="false" collective="false" import="true" targetId="27ab-4f27-5703-a40f" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="45f1-0e3a-06d9-c2a7" name="New CategoryLink" hidden="false" targetId="c5b6-63ee-3f81-25f2" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="5f24-077a-794b-bbde" name="[W] Tiger (P)" hidden="false" collective="false" import="true" targetId="dce3-dd07-476e-d810" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="421e-d19d-b245-5bd1" name="New CategoryLink" hidden="false" targetId="58fd-8352-c305-41bb" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="e07b-e526-54e5-5889" name="Sd Kfz 221 &amp; 222 Light Scout Troop" hidden="true" collective="false" import="true" targetId="1805-7cf8-8b3f-a2df" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="879a-0b04-2062-775f" type="greaterThan"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="c2c4-ab71-8ca4-1a93" name="New CategoryLink" hidden="false" targetId="b531-2fd7-ec0e-d214" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="d0a1-e82b-489e-0e8b" name="[AC] Sd Kfz 231 Heavy Scout Troop" hidden="true" collective="false" import="true" targetId="8a59-b461-9bd1-6401" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="879a-0b04-2062-775f" type="greaterThan"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="bd6e-cb12-866f-12c1" name="New CategoryLink" hidden="false" targetId="b531-2fd7-ec0e-d214" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="1734-c52e-f1f8-022e" name="5cm Tank-Hunter Platoon" hidden="true" collective="false" import="true" targetId="1b66-d365-c756-7a90" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8195-e8fe-d94d-0863" type="greaterThan"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="e770-143e-dd92-2bce" name="New CategoryLink" hidden="false" targetId="b531-2fd7-ec0e-d214" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="e9b1-4a19-dcfe-16b6" name="[P] Panzer III Tank Platoon (7.5cm)" hidden="true" collective="false" import="true" targetId="82ac-3611-246d-14a3" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="912e-3dba-2ff4-ab44" type="greaterThan"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="8103-96a2-8459-19bc" name="New CategoryLink" hidden="false" targetId="b531-2fd7-ec0e-d214" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="c7b5-ccb1-d92e-ea97" name="[P] Panzer III (Mixed) Tank Platoon" hidden="true" collective="false" import="true" targetId="f4ec-d95d-52cf-9d06" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="912e-3dba-2ff4-ab44" type="greaterThan"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="028f-f134-838f-f07f" name="New CategoryLink" hidden="false" targetId="b531-2fd7-ec0e-d214" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="facb-5ae2-efbe-aec0" name="[Panzer III (Uparmoured) Tank Platoon" hidden="true" collective="false" import="true" targetId="b3d8-a821-fa00-8c48" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="912e-3dba-2ff4-ab44" type="greaterThan"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="f78d-76a0-fa6f-09a3" name="New CategoryLink" hidden="false" targetId="b531-2fd7-ec0e-d214" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="de64-52aa-6002-34dd" name="Fallschirm Pioneer Platoon" hidden="false" collective="false" import="true" targetId="fc1b-0117-bfae-d9bf" type="selectionEntry">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="af9c-30f3-235b-5618" type="max"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink id="3f66-2f37-8300-11b0" name="New CategoryLink" hidden="false" targetId="9be3-4dab-91f0-f7c5" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="47ba-df77-e552-d43a" name="SUPPORT] Heavy AT Support Unit" hidden="false" collective="false" import="true" targetId="12d0-e7e5-e7b2-a4e1" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="c3d8-15d2-e3a2-dcac" name="New CategoryLink" hidden="false" targetId="9be3-4dab-91f0-f7c5" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="d8bc-1e8f-0acb-cf7b" name="SUPPORT] Observation Post Support Unit" hidden="true" collective="false" import="true" targetId="deae-76d6-e7a0-ee09" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="87af-5a4a-1acd-f842" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8b75-1589-5690-3654" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="854e-8f81-92ae-d45b" name="New CategoryLink" hidden="false" targetId="9be3-4dab-91f0-f7c5" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="e67f-ba36-23bc-15e4" name="SUPPORT] Anti-Air Support Unit" hidden="false" collective="false" import="true" targetId="6071-147c-22e8-f008" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="8fd8-2347-c393-8ee9" name="New CategoryLink" hidden="false" targetId="9be3-4dab-91f0-f7c5" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="6504-f54a-46c2-561f" name="SUPPORT] Artillery Support Unit" hidden="false" collective="false" import="true" targetId="3441-c8cd-e5d5-4d45" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="4206-4cd4-0fcb-054b" name="New CategoryLink" hidden="false" targetId="9be3-4dab-91f0-f7c5" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="00f5-4c7a-b2dd-8c41" name="SUPPORT] AT Support Unit" hidden="false" collective="false" import="true" targetId="982f-136d-902e-f70e" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="e569-50fc-560d-aacb" name="New CategoryLink" hidden="false" targetId="9be3-4dab-91f0-f7c5" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="5a02-4d0d-ceb1-640d" name="Fallschirmjager Company" hidden="false" collective="false" import="true" targetId="3278-296b-fd55-cec9" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="28b6-db0f-b0e2-930d" name="New CategoryLink" hidden="false" targetId="5630-abd3-15d8-5cc6" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="bbb7-d3a1-6ba8-8349" name="Fallschirmjager Platoon" hidden="true" collective="false" import="true" targetId="6b07-e1ec-03dc-4f5d" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3278-296b-fd55-cec9" type="greaterThan"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="37be-c837-6ff4-cba2" name="New CategoryLink" hidden="false" targetId="b531-2fd7-ec0e-d214" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+  </entryLinks>
+  <sharedSelectionEntries>
+    <selectionEntry id="8b75-1589-5690-3654" name="10.5cm Artillery Battery" hidden="false" collective="false" import="true" type="unit">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6ac3-a248-7cee-1f2e" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="9083-0578-69e1-49da" name="10.5cm howitzer" hidden="false" targetId="32af-b10e-13da-282b" type="profile"/>
+        <infoLink id="875f-fd36-557e-85a1" name="10.5cm howitzer [Artillery]" hidden="false" targetId="3de8-6ce7-b2a1-e6b8" type="profile"/>
+        <infoLink id="482d-03e2-07d8-1893" name="Forward Firing" hidden="false" targetId="fa9d-68f6-57d9-dc5d" type="rule"/>
+        <infoLink id="669c-d81e-2dca-7f1e" name="Large Gun" hidden="false" targetId="183b-aef0-86e1-693f" type="rule"/>
+        <infoLink id="66fb-5948-149e-1129" name="Smoke" hidden="false" targetId="6f51-dbfe-55b0-a6d0" type="rule"/>
+        <infoLink id="d6cf-fc2f-9e29-d040" name="Gun" hidden="false" targetId="139e-9d64-28a3-a3dd" type="rule"/>
+        <infoLink id="1515-e058-6fba-8662" name="10.5cm howitzer Direct Fire" hidden="false" targetId="b05f-ec9a-abc8-3b66" type="profile"/>
+        <infoLink id="b7a1-cbef-e2c7-ff54" name="Slow Firing" hidden="false" targetId="e215-d5bf-83ce-606a" type="rule"/>
+        <infoLink id="fd74-ea87-a3a0-9827" name="Brutal" hidden="false" targetId="97da-9a33-4ff1-56f2" type="rule"/>
+        <infoLink id="9a58-acea-63dc-876c" name="Smoke Bombardment" hidden="false" targetId="5450-1722-5ad1-1d61" type="rule"/>
+        <infoLink id="7aa0-1cd2-a93e-1555" name="Gun Shield" hidden="false" targetId="2f2d-c5a9-ef7e-1b5e" type="rule"/>
+      </infoLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="331f-70a2-4636-1c56" name="Unit Size" publicationId="b8e5-51cf-456c-eafb" hidden="false" collective="false" import="true" defaultSelectionEntryId="df0b-547b-7a9f-daf7">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="57bf-d592-7955-0512" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fd17-eca6-6357-da1d" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="df0b-547b-7a9f-daf7" name="2x 10.5cm howitzer" hidden="false" collective="false" import="true" type="upgrade">
+              <costs>
+                <cost name="pts" typeId="995a-4d67-6920-bfe4" value="7.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="d4e2-0cd9-52ac-7a23" name="4x 10.5cm howitzer" hidden="false" collective="false" import="true" type="upgrade">
+              <costs>
+                <cost name="pts" typeId="995a-4d67-6920-bfe4" value="14.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="87af-5a4a-1acd-f842" name="10.5cm Gun or 15cm Armoured Artillery Battery" hidden="false" collective="false" import="true" type="unit">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ce90-7614-cbe1-21d4" type="max"/>
+      </constraints>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="3ab4-7e0f-f2df-d991" name="Type" hidden="false" collective="false" import="true" defaultSelectionEntryId="d476-0e42-18ba-d246">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="465b-e065-5140-1c65" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="26f4-d779-4d8d-2d43" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="a998-3d74-4996-09e9" name="10.5cm Artillery Battery" hidden="false" collective="false" import="true" targetId="8b75-1589-5690-3654" type="selectionEntry"/>
+            <entryLink id="d476-0e42-18ba-d246" name="15cm (Sf) Lorraine Schlepper Artillery Battery" hidden="false" collective="false" import="true" targetId="d2d5-99f1-4c07-97d1" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1b66-d365-c756-7a90" name="5cm Tank-Hunter Platoon" hidden="false" collective="false" import="true" type="unit">
+      <infoLinks>
+        <infoLink id="98f4-c294-b1cf-8d6c" name="Third Reich" hidden="false" targetId="0d32-e61c-3e35-7b9e" type="rule"/>
+        <infoLink id="497e-dafe-6dcc-6830" name="5cm gun" hidden="false" targetId="dd70-41d8-f946-6066" type="profile"/>
+        <infoLink id="02d0-9e5e-b7ef-d5fa" name="5cm gun [Unit]" hidden="false" targetId="d223-f581-fdc0-afbc" type="profile"/>
+        <infoLink id="fa2d-3e8d-5e26-7593" name="Forward Firing" hidden="false" targetId="fa9d-68f6-57d9-dc5d" type="rule"/>
+        <infoLink id="f2d8-f010-5c43-7bdb" name="Gun" hidden="false" targetId="139e-9d64-28a3-a3dd" type="rule"/>
+        <infoLink id="a352-cd3f-9510-305a" name="Gun Shield" hidden="false" targetId="2f2d-c5a9-ef7e-1b5e" type="rule"/>
+      </infoLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="1a5d-dd3a-3abc-d65e" name="Unit Size" publicationId="b8e5-51cf-456c-eafb" hidden="false" collective="false" import="true" defaultSelectionEntryId="2c05-eab1-6a5e-8e6c">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="10e7-f893-c25c-1b7c" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0223-5b66-29c6-495a" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="45d0-f38e-b301-b56c" name="3x 5cm gun" hidden="false" collective="false" import="true" type="model">
+              <costs>
+                <cost name="pts" typeId="995a-4d67-6920-bfe4" value="12.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="2c05-eab1-6a5e-8e6c" name="2x 5cm gun" hidden="false" collective="false" import="true" type="model">
+              <costs>
+                <cost name="pts" typeId="995a-4d67-6920-bfe4" value="8.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="233e-1bc9-4a0c-d1fd" name="8.8cm Heavy AA Platoon" hidden="false" collective="false" import="true" type="unit">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f735-2f7d-172b-77e7" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="1648-1236-0db7-69a9" name="Self-Defence AA" hidden="false" targetId="6c0b-8d39-70b6-9d1c" type="rule"/>
+        <infoLink id="65d1-2fa1-cf88-7369" name="8.8cm AA gun" hidden="false" targetId="215d-c40a-ac50-2433" type="profile"/>
+        <infoLink id="e8ea-d6e1-bf25-9054" name="Large Gun" hidden="false" targetId="183b-aef0-86e1-693f" type="rule"/>
+        <infoLink id="0e5d-57bd-27ae-7dbb" name="8.8cm AA gun" hidden="false" targetId="c984-7646-3ae3-a803" type="profile"/>
+        <infoLink id="71a7-f87e-cc37-9058" name="Third Reich" hidden="false" targetId="0d32-e61c-3e35-7b9e" type="rule"/>
+        <infoLink id="56c8-b21a-f079-4bb5" name="Gun Shield" hidden="false" targetId="2f2d-c5a9-ef7e-1b5e" type="rule"/>
+        <infoLink id="6f6e-4622-20bc-cce7" name="Gun" hidden="false" targetId="139e-9d64-28a3-a3dd" type="rule"/>
+      </infoLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="9a6c-696b-cec0-542c" name="Unit Size" publicationId="b8e5-51cf-456c-eafb" hidden="false" collective="false" import="true" defaultSelectionEntryId="ec01-7b1a-a9a2-aa44">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9158-f4e0-912b-e19c" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c957-5e38-8063-0475" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="1911-ba56-6d94-ab61" name="4x 8.8cm AA gun" hidden="false" collective="false" import="true" type="upgrade">
+              <costs>
+                <cost name="pts" typeId="995a-4d67-6920-bfe4" value="24.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="60a8-b244-f3df-f7e0" name="3x 8.8cm AA gun" hidden="false" collective="false" import="true" type="upgrade">
+              <costs>
+                <cost name="pts" typeId="995a-4d67-6920-bfe4" value="18.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="bd51-d83f-6f94-d683" name="2x 8.8cm AA gun" hidden="false" collective="false" import="true" type="upgrade">
+              <costs>
+                <cost name="pts" typeId="995a-4d67-6920-bfe4" value="12.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="ec01-7b1a-a9a2-aa44" name="1x 8.8cm AA gun" hidden="false" collective="false" import="true" type="upgrade">
+              <costs>
+                <cost name="pts" typeId="995a-4d67-6920-bfe4" value="6.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="8195-e8fe-d94d-0863" name="Afrika Rifle Company" hidden="false" collective="false" import="true" type="unit">
+      <selectionEntries>
+        <selectionEntry id="5b62-2286-69d5-8cb1" name="Afrika Rifle Company HQ" publicationId="b8e5-51cf-456c-eafb" hidden="false" collective="false" import="true" type="unit">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4f8d-5fc2-95f6-cd6a" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bc7a-8565-04ce-8aac" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="9c92-8ee9-1dac-44a1" name="Pinned ROF 1" hidden="false" targetId="3284-2a9d-b7f4-e17a" type="rule"/>
+            <infoLink id="3a37-34a2-40b0-ce57" name="MP40 SMG team" hidden="false" targetId="a028-247a-e0b3-b53a" type="profile"/>
+            <infoLink id="131b-7542-6233-ecd3" name="Stormtroopers" hidden="false" targetId="5b29-2623-7f34-fc95" type="rule"/>
+            <infoLink id="0a5f-0557-76d3-745b" name="MP40 SMG team" hidden="false" targetId="198a-2c9e-9db8-5d2a" type="profile"/>
+            <infoLink id="895d-047e-92b9-bf74" name="Third Reich" hidden="false" targetId="0d32-e61c-3e35-7b9e" type="rule"/>
+          </infoLinks>
+          <selectionEntries>
+            <selectionEntry id="8d15-97ed-ff9c-e06f" name="2x MP40 SMG team" hidden="false" collective="false" import="true" type="model">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6146-e503-845b-ef72" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bea8-d311-ed7c-bd3b" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="995a-4d67-6920-bfe4" value="2.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <costs>
+            <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="f31e-1889-ba7c-e333" name="5cm Tank-Hunter Platoon" hidden="false" collective="false" import="true" targetId="1b66-d365-c756-7a90" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="b160-e16e-9323-0adb" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="5353-7fff-715d-4927" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="f779-7462-8443-55e5" name="5cm Tank-Hunter Platoon" hidden="false" collective="false" import="true" targetId="1b66-d365-c756-7a90" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="655a-6c5c-61a0-72e5" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="738f-90b5-bebc-9896" name="5cm Tank-Hunter Platoon" hidden="false" collective="false" import="true" targetId="1b66-d365-c756-7a90" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="456f-ba4f-70d1-da83" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="fba4-03fe-4a96-15ed" name="Sd Kfz 10/4 Light AA Platoon" hidden="false" collective="false" import="true" targetId="e176-eaf3-6806-dfb4" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b206-914b-aed6-d2c0" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="daad-39ec-a729-aa9a" name="Afrika Rifle Platoon" hidden="false" collective="false" import="true" targetId="a3e3-a0a5-b1cb-155c" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="dc02-6921-2a0e-8f9e" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="2258-c9a0-eedf-f650" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="9324-9a54-6952-742b" name="Afrika Rifle Platoon" hidden="false" collective="false" import="true" targetId="a3e3-a0a5-b1cb-155c" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="6427-5a70-4205-8278" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="0f99-8107-cc55-5e9a" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="ddcd-b903-ef9f-58ac" name="Afrika Rifle Platoon" hidden="false" collective="false" import="true" targetId="a3e3-a0a5-b1cb-155c" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="191b-ac99-0cac-8c12" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a3e3-a0a5-b1cb-155c" name="Afrika Rifle Platoon" hidden="false" collective="false" import="true" type="unit">
+      <infoLinks>
+        <infoLink id="f277-0bf1-1878-94bb" name="Stormtroopers" hidden="false" targetId="5b29-2623-7f34-fc95" type="rule"/>
+        <infoLink id="c114-d6a8-6cce-9516" name="Third Reich" hidden="false" targetId="0d32-e61c-3e35-7b9e" type="rule"/>
+        <infoLink id="3dfe-d13f-d30b-7c6a" name="MG34 team" hidden="false" targetId="da6b-9ea6-5c21-092d" type="profile"/>
+      </infoLinks>
+      <selectionEntries>
+        <selectionEntry id="c6c0-865d-169f-9dbf" name="1x 8cm mortar" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1d31-84c2-5fe9-6283" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="736a-1a03-2c07-66a3" name="8cm mortar" hidden="false" targetId="5328-88c0-a5ee-781a" type="profile"/>
+            <infoLink id="462a-cfb4-b48e-0c46" name="Assault 4+" hidden="false" targetId="dc00-41ba-b4dd-f068" type="rule"/>
+            <infoLink id="66c8-096e-9c4b-11ed" name="Heavy Weapon" hidden="false" targetId="edf7-ad9c-029c-94fe" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="995a-4d67-6920-bfe4" value="2.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="e3c1-6ad4-573c-c645" name="1x sMG34 HMG" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3805-0694-a0bd-1ff1" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="e2d2-3063-a9d0-a3d9" name="sMG34 HMG" hidden="false" targetId="bae9-90b2-6eb3-95c6" type="profile"/>
+            <infoLink id="35b2-3e42-5688-1cb7" name="Assault 4+" hidden="false" targetId="dc00-41ba-b4dd-f068" type="rule"/>
+            <infoLink id="19c6-d50b-db1b-6722" name="Heavy Weapon" hidden="false" targetId="edf7-ad9c-029c-94fe" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="995a-4d67-6920-bfe4" value="1.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="7dd1-dd47-fa45-b956" name="Unit Size" publicationId="b8e5-51cf-456c-eafb" hidden="false" collective="false" import="true" defaultSelectionEntryId="620a-d759-db64-c0aa">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="833a-ad63-05b4-5cf5" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d5a1-2f2f-52aa-6503" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="fb49-30d6-2515-4c14" name="4x MG34, 1x 2.8cm anti-tank rifle" hidden="false" collective="false" import="true" type="upgrade">
+              <selectionEntries>
+                <selectionEntry id="e4d0-6e9c-563f-b0a0" name="4x MG34 team" hidden="false" collective="false" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7276-fd48-db5c-1f66" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="98dc-facd-8d3a-d52d" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="f0f0-305d-08ec-5f07" name="MG34 team (W)" hidden="false" targetId="dc51-5020-0fc4-c611" type="profile"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="e942-2d6f-1979-6c86" name="1x 2.8cm anti-tank rifle" hidden="false" collective="false" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7b71-f259-4f44-580c" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9e0a-218e-ad24-7e80" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="093c-6d66-318f-0db4" name="Assault 4+" hidden="false" targetId="dc00-41ba-b4dd-f068" type="rule"/>
+                    <infoLink id="6046-02f9-969d-38ae" name="Heavy Weapon" hidden="false" targetId="edf7-ad9c-029c-94fe" type="rule"/>
+                    <infoLink id="a3cc-85cd-d8c7-bdd1" name="No HE" hidden="false" targetId="b000-d0f1-08fd-0d43" type="rule"/>
+                    <infoLink id="3423-d8c0-f719-4089" name="2.8cm anti-tank rifle" hidden="false" targetId="5589-f659-399a-20b8" type="profile"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <costs>
+                <cost name="pts" typeId="995a-4d67-6920-bfe4" value="7.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="620a-d759-db64-c0aa" name="3x MG34, 1x 2.8cm anti-tank rifle" hidden="false" collective="false" import="true" type="upgrade">
+              <selectionEntries>
+                <selectionEntry id="46fe-d1af-39aa-4974" name="3x MG34 team" hidden="false" collective="false" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8565-46e6-8ac4-ff84" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="06a2-3c4f-292f-ed1c" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="c12d-f8fc-75a7-9764" name="MG34 team (W)" hidden="false" targetId="dc51-5020-0fc4-c611" type="profile"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="8366-b3ff-a354-17d0" name="1x 2.8cm anti-tank rifle" hidden="false" collective="false" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7d41-1831-7b98-d9c5" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="72dd-e5c6-8ad3-6327" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="c14d-dcc8-d7e7-e947" name="Assault 4+" hidden="false" targetId="dc00-41ba-b4dd-f068" type="rule"/>
+                    <infoLink id="2527-52a7-d405-6732" name="Heavy Weapon" hidden="false" targetId="edf7-ad9c-029c-94fe" type="rule"/>
+                    <infoLink id="2a13-414b-d370-a3b2" name="No HE" hidden="false" targetId="b000-d0f1-08fd-0d43" type="rule"/>
+                    <infoLink id="d2ca-bbce-536c-0c33" name="2.8cm anti-tank rifle" hidden="false" targetId="5589-f659-399a-20b8" type="profile"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <costs>
+                <cost name="pts" typeId="995a-4d67-6920-bfe4" value="6.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="879a-0b04-2062-775f" name="Armoured Car Company" hidden="false" collective="false" import="true" type="unit">
+      <selectionEntries>
+        <selectionEntry id="dc3e-76c7-4724-abe5" name="Armoured Car Company HQ" hidden="false" collective="false" import="true" type="unit">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d5b0-a8f5-b4c3-78d6" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="14b2-b138-26bd-c751" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="0aed-ce49-de2b-d9e7" name="Sd Kfz 222 &amp; 221 [Unit]" hidden="false" targetId="b9c5-805b-4d8e-f2e2" type="profile"/>
+            <infoLink id="42c6-d68f-aeac-99ea" name="Scout" hidden="false" targetId="967a-118e-dc01-7e0b" type="rule"/>
+            <infoLink id="84e5-2b35-4397-5bfc" name="Self-Defence AA" hidden="false" targetId="6c0b-8d39-70b6-9d1c" type="rule"/>
+            <infoLink id="6f41-ab5c-9f6f-b0cc" name="Spearhead" hidden="false" targetId="70fc-43a3-1ed1-1b01" type="rule"/>
+            <infoLink id="df34-fda0-6af0-48da" name="Stormtroopers" hidden="false" targetId="5b29-2623-7f34-fc95" type="rule"/>
+          </infoLinks>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="dda6-557f-8b26-1594" name="Type" hidden="false" collective="false" import="true" defaultSelectionEntryId="10ac-f1e8-86e1-bec2">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="00f6-6c6c-786f-60bd" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eab5-cbc3-2edc-55c2" type="max"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="cc80-9d2d-b6b7-fc5b" name="1x Sd Kfz 221 (2.8cm)" hidden="false" collective="false" import="true" type="model">
+                  <infoLinks>
+                    <infoLink id="3cb4-d416-ebfb-bb9d" name="Sd Kfz 221 (2.8cm)" hidden="false" targetId="269b-6001-8015-8bcc" type="profile"/>
+                    <infoLink id="d81f-d3e8-ec55-0a44" name="No HE" hidden="false" targetId="b000-d0f1-08fd-0d43" type="rule"/>
+                    <infoLink id="5f22-022c-5f08-ef80" name="Slow Firing" hidden="false" targetId="e215-d5bf-83ce-606a" type="rule"/>
+                    <infoLink id="9ceb-e730-e119-823c" name="Forward Firing" hidden="false" targetId="fa9d-68f6-57d9-dc5d" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="995a-4d67-6920-bfe4" value="1.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="10ac-f1e8-86e1-bec2" name="1x Sd Kfz 221 (MG)" hidden="false" collective="false" import="true" type="model">
+                  <infoLinks>
+                    <infoLink id="a0bf-7858-9f70-eac4" name="Sd Kfz 222 &amp; 221 (MG)" hidden="false" targetId="c190-2257-2267-8970" type="profile"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="995a-4d67-6920-bfe4" value="1.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="8fee-4c4e-1404-4072" name="***Sd Kfz 221 &amp; 222 Light Scout Troop" hidden="false" collective="false" import="true" targetId="1805-7cf8-8b3f-a2df" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e63e-8d91-3773-5b71" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="efb1-e108-4a8f-cc8c" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="c632-fbf8-fbda-2e9f" name="***Afrika Rifle Platoon" hidden="false" collective="false" import="true" targetId="a3e3-a0a5-b1cb-155c" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e855-ebaf-3c63-1173" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="1535-102e-4c1c-9755" name="*** Sd Kfz 231 Heavy Scout Troop" hidden="false" collective="false" import="true" targetId="8a59-b461-9bd1-6401" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1475-f214-fc2e-fcba" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="99dd-8d6e-b6cf-e448" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="e606-ea96-b513-f28a" name="***5cm Tank-Hunter Platoon" hidden="false" collective="false" import="true" targetId="1b66-d365-c756-7a90" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0196-1b12-ba48-7a61" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="74a1-4d45-b1f2-77e9" name="*** Sd Kfz 231 Heavy Scout Troop" hidden="false" collective="false" import="true" targetId="8a59-b461-9bd1-6401" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="57ac-1c0d-340b-254f" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="34ea-6b8f-e69a-d1a7" name="*** Sd Kfz 231 Heavy Scout Troop" hidden="false" collective="false" import="true" targetId="8a59-b461-9bd1-6401" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="914f-ad4a-e282-781c" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="9690-01d6-1eb2-2a69" name="***Sd Kfz 221 &amp; 222 Light Scout Troop" hidden="false" collective="false" import="true" targetId="1805-7cf8-8b3f-a2df" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf43-712d-fef3-607e" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="cc13-5afa-d107-3e63" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="a61f-aa8c-fcd9-733d" name="***Sd Kfz 221 &amp; 222 Light Scout Troop" hidden="false" collective="false" import="true" targetId="1805-7cf8-8b3f-a2df" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3a8a-de60-a522-8ca2" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="ca16-a6bc-ca0c-31d6" name="***Sd Kfz 221 &amp; 222 Light Scout Troop" hidden="false" collective="false" import="true" targetId="1805-7cf8-8b3f-a2df" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6bfa-76e9-6de0-1244" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="1cbd-e2ae-2098-68ea" name="***Sd Kfz 221 &amp; 222 Light Scout Troop" hidden="false" collective="false" import="true" targetId="1805-7cf8-8b3f-a2df" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d335-4e06-2009-52bc" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="598b-0680-3a53-2a00" name="***Sd Kfz 221 &amp; 222 Light Scout Troop" hidden="false" collective="false" import="true" targetId="1805-7cf8-8b3f-a2df" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="75ef-e6fa-d6ad-8be5" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="cc0b-e2ed-e5ac-bfbd" name="***Sd Kfz 221 &amp; 222 Light Scout Troop" hidden="false" collective="false" import="true" targetId="1805-7cf8-8b3f-a2df" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="645d-fdcb-5624-c384" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="deb2-69a5-6c02-9efd" name="***Sd Kfz 221 &amp; 222 Light Scout Troop" hidden="false" collective="false" import="true" targetId="1805-7cf8-8b3f-a2df" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7e93-efe6-6151-2c97" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="de9e-eba7-2d35-9d81" name="Ju 87 Stuka Dive Bomber Flight" hidden="false" collective="false" import="true" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0881-5903-11eb-fb1e" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="2eaf-7ede-2b20-9c13" name="Bombs" hidden="false" targetId="78a2-7146-034e-a601" type="rule"/>
+        <infoLink id="aa3c-a1db-5092-f1aa" name="Ju 87 Stuka" hidden="false" targetId="1303-568a-38b7-564d" type="profile"/>
+        <infoLink id="f82d-a7f3-135f-cde3" name="500kg bombs" hidden="false" targetId="5634-09d2-861f-5791" type="profile"/>
+      </infoLinks>
+      <selectionEntries>
+        <selectionEntry id="ac90-8401-9001-8027" name="2x Ju 87 Stuka" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8d78-8846-93a7-c3aa" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="027f-f570-186a-0452" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="995a-4d67-6920-bfe4" value="9.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4b88-0aac-85da-1695" name="Panzer II OP Observation Post " hidden="false" collective="false" import="true" type="unit">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3af5-04cd-a3a5-3aa6" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="efa3-5ce2-6e85-3c82" name="Observer" hidden="false" targetId="8153-56ce-71c0-391b" type="rule"/>
+        <infoLink id="24d4-edc3-a3f4-89cc" name="Panzer II OP" hidden="false" targetId="fc6b-e27c-2d3d-fee2" type="profile"/>
+        <infoLink id="48b6-0cdf-ed26-221b" name="Stormtroopers" hidden="false" targetId="5b29-2623-7f34-fc95" type="rule"/>
+        <infoLink id="e6cd-502b-ce96-562e" name="Panzer II (2cm) [Weapon]" hidden="false" targetId="9fec-a2fe-7262-a9fc" type="profile"/>
+        <infoLink id="8f9e-b882-9fac-6ce7" name="Independent Tank Unit" hidden="false" targetId="b650-398e-5817-50fb" type="rule"/>
+        <infoLink id="161e-a322-db89-a128" name="Panzer II (MG)" hidden="false" targetId="85a8-b4f2-1c62-0ec0" type="profile"/>
+        <infoLink id="fda1-c5c5-6d47-3f9a" name="Scout" hidden="false" targetId="967a-118e-dc01-7e0b" type="rule"/>
+      </infoLinks>
+      <selectionEntries>
+        <selectionEntry id="be52-02c2-2e12-1f0d" name="1x Panzer II OP" hidden="false" collective="false" import="true" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5fe4-955a-b44d-5f23" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ce84-fda8-5892-72bd" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="995a-4d67-6920-bfe4" value="1.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="912e-3dba-2ff4-ab44" name="Panzer III Tank Company" hidden="false" collective="false" import="true" type="upgrade">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="7cac-18a1-c4df-6c72" name="0) Panzer III Command HQ" hidden="false" collective="false" import="true" defaultSelectionEntryId="178f-6fdb-f53a-ba95">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e754-0094-be06-d5e6" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="094a-b93c-2ac7-c499" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="178f-6fdb-f53a-ba95" name="Panzer III Company HQ" publicationId="b8e5-51cf-456c-eafb" hidden="false" collective="false" import="true" type="unit">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eb5d-b96a-cbd9-7e7b" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="def3-85b5-7eda-a3b0" name="Protected Ammo" hidden="false" targetId="ad4a-22fc-2234-7874" type="rule"/>
+                <infoLink id="2df3-4734-9ea7-49ab" name="Third Reich" hidden="false" targetId="0d32-e61c-3e35-7b9e" type="rule"/>
+                <infoLink id="6b2e-461b-7ae1-a586" name="Stormtroopers" hidden="false" targetId="5b29-2623-7f34-fc95" type="rule"/>
+                <infoLink id="ec55-8833-536a-531c" name="Panzer III" hidden="false" targetId="d19f-9a03-5a2f-b5a3" type="profile"/>
+                <infoLink id="4f07-de8d-b118-c69b" name="Panzer III (MGs)" hidden="false" targetId="6b68-30d1-3bf7-9c64" type="profile"/>
+              </infoLinks>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="bc30-3672-62ff-63aa" name="Unit Size" hidden="false" collective="false" import="true" defaultSelectionEntryId="ae0e-3a29-af91-bc54">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="82ef-b3b1-660f-2e2b" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0e48-ed6b-d122-7fc1" type="max"/>
+                  </constraints>
+                  <selectionEntries>
+                    <selectionEntry id="449a-9d04-b28d-8cee" name="1x Panzer III (7.5cm)" hidden="false" collective="false" import="true" type="model">
+                      <infoLinks>
+                        <infoLink id="355e-538e-be94-8296" name="HEAT" hidden="false" targetId="9a14-019a-eb63-0b40" type="rule"/>
+                        <infoLink id="c586-8c84-fd4a-f068" name="Panzer III (7.5cm)" hidden="false" targetId="e95a-01e2-de0f-70be" type="profile"/>
+                      </infoLinks>
+                      <costs>
+                        <cost name="pts" typeId="995a-4d67-6920-bfe4" value="8.0"/>
+                      </costs>
+                    </selectionEntry>
+                    <selectionEntry id="1c1b-bb93-a84e-281c" name="2x Panzer III (short 5cm)" hidden="false" collective="false" import="true" type="model">
+                      <infoLinks>
+                        <infoLink id="212c-6672-c7f6-c7fc" name="Panzer III (short 5cm)" hidden="false" targetId="27d6-4340-e9e0-489a" type="profile"/>
+                      </infoLinks>
+                      <costs>
+                        <cost name="pts" typeId="995a-4d67-6920-bfe4" value="10.0"/>
+                      </costs>
+                    </selectionEntry>
+                    <selectionEntry id="425d-88be-224c-2c87" name="2x Panzer III (7.5cm)" hidden="false" collective="false" import="true" type="model">
+                      <infoLinks>
+                        <infoLink id="133b-e17d-1996-8042" name="Panzer III (7.5cm)" hidden="false" targetId="e95a-01e2-de0f-70be" type="profile"/>
+                        <infoLink id="302f-f966-bdad-3f03" name="HEAT" hidden="false" targetId="9a14-019a-eb63-0b40" type="rule"/>
+                      </infoLinks>
+                      <costs>
+                        <cost name="pts" typeId="995a-4d67-6920-bfe4" value="16.0"/>
+                      </costs>
+                    </selectionEntry>
+                    <selectionEntry id="ae0e-3a29-af91-bc54" name="1x Panzer III (short 5cm)" hidden="false" collective="false" import="true" type="model">
+                      <infoLinks>
+                        <infoLink id="8aec-ba4c-81ed-d29f" name="Panzer III (short 5cm)" hidden="false" targetId="27d6-4340-e9e0-489a" type="profile"/>
+                      </infoLinks>
+                      <costs>
+                        <cost name="pts" typeId="995a-4d67-6920-bfe4" value="5.0"/>
+                      </costs>
+                    </selectionEntry>
+                    <selectionEntry id="f718-f545-fc88-ceda" name="1x Panzer III (long 5cm)" hidden="false" collective="false" import="true" type="model">
+                      <infoLinks>
+                        <infoLink id="6d7f-a387-2e42-8c3b" name="Panzer III (long 5cm)" hidden="false" targetId="c348-31c6-abda-445f" type="profile"/>
+                      </infoLinks>
+                      <costs>
+                        <cost name="pts" typeId="995a-4d67-6920-bfe4" value="7.0"/>
+                      </costs>
+                    </selectionEntry>
+                    <selectionEntry id="91a6-1092-2c3b-495a" name="2x Panzer III (long 5cm)" hidden="false" collective="false" import="true" type="model">
+                      <infoLinks>
+                        <infoLink id="1db5-8609-5858-5520" name="Panzer III (long 5cm)" hidden="false" targetId="c348-31c6-abda-445f" type="profile"/>
+                      </infoLinks>
+                      <costs>
+                        <cost name="pts" typeId="995a-4d67-6920-bfe4" value="14.0"/>
+                      </costs>
+                    </selectionEntry>
+                    <selectionEntry id="5004-5d83-34b6-653c" name="2x Panzer III (1x short 5cm &amp; 1x long 5cm)" hidden="false" collective="false" import="true" type="model">
+                      <infoLinks>
+                        <infoLink id="feb7-d5a3-5edd-e58e" name="Panzer III (long 5cm)" hidden="false" targetId="c348-31c6-abda-445f" type="profile"/>
+                        <infoLink id="17a1-1c4c-4a15-6107" name="Panzer III (short 5cm)" hidden="false" targetId="27d6-4340-e9e0-489a" type="profile"/>
+                      </infoLinks>
+                      <costs>
+                        <cost name="pts" typeId="995a-4d67-6920-bfe4" value="12.0"/>
+                      </costs>
+                    </selectionEntry>
+                  </selectionEntries>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <costs>
+                <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="6569-b916-9335-04f1" name="Panzer III (Uparmoured) Company HQ" publicationId="b8e5-51cf-456c-eafb" hidden="false" collective="false" import="true" type="unit">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d44a-af60-5ab1-33dc" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="e0f3-6404-4714-7b14" name="Protected Ammo" hidden="false" targetId="ad4a-22fc-2234-7874" type="rule"/>
+                <infoLink id="b4cd-33a6-9421-0a7b" name="Third Reich" hidden="false" targetId="0d32-e61c-3e35-7b9e" type="rule"/>
+                <infoLink id="d523-95a0-31fa-7faf" name="Stormtroopers" hidden="false" targetId="5b29-2623-7f34-fc95" type="rule"/>
+                <infoLink id="cdfd-eeda-7dd3-39af" name="Panzer III (uparmoured)" hidden="false" targetId="c1d6-72c3-6ff0-b7ad" type="profile"/>
+                <infoLink id="34dc-09a0-35a4-c270" name="Panzer III (MGs)" hidden="false" targetId="6b68-30d1-3bf7-9c64" type="profile"/>
+                <infoLink id="318b-d059-9db0-a835" name="Panzer III (long 5cm)" hidden="false" targetId="c348-31c6-abda-445f" type="profile"/>
+              </infoLinks>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="a523-3fa7-e559-6882" name="Unit Size" hidden="false" collective="false" import="true" defaultSelectionEntryId="724b-044b-b152-1b55">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1102-8355-4dc8-7345" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3f9d-4f92-7b70-a711" type="max"/>
+                  </constraints>
+                  <selectionEntries>
+                    <selectionEntry id="724b-044b-b152-1b55" name="1x Panzer III (uparmoured)" hidden="false" collective="false" import="true" type="upgrade">
+                      <costs>
+                        <cost name="pts" typeId="995a-4d67-6920-bfe4" value="8.0"/>
+                      </costs>
+                    </selectionEntry>
+                    <selectionEntry id="186c-c714-fed5-f72c" name="2x Panzer III (uparmoured)" hidden="false" collective="false" import="true" type="upgrade">
+                      <costs>
+                        <cost name="pts" typeId="995a-4d67-6920-bfe4" value="16.0"/>
+                      </costs>
+                    </selectionEntry>
+                  </selectionEntries>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <costs>
+                <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="0084-4c7e-8f7f-06c5" name="2) Panzer III or IV Platoon" hidden="false" collective="false" import="true" defaultSelectionEntryId="bfae-bea3-c47a-f989">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2ebe-04b0-ba59-6b22" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e1ee-809a-8b45-e67e" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="cb5b-96ce-38ff-e9a3" name="***Panzer IV Tank Platoon" hidden="false" collective="false" import="true" targetId="2fe8-236b-99f4-44ce" type="selectionEntry"/>
+            <entryLink id="09e6-d272-61ef-0025" name="Panzer III (Mixed) Tank Platoon" hidden="false" collective="false" import="true" targetId="f4ec-d95d-52cf-9d06" type="selectionEntry"/>
+            <entryLink id="40f6-bcca-a364-949f" name="Panzer III Tank Platoon (7.5cm)" hidden="false" collective="false" import="true" targetId="82ac-3611-246d-14a3" type="selectionEntry"/>
+            <entryLink id="4ccd-ba20-8071-5df5" name="**Panzer III (Uparmoured) Tank Platoon" hidden="false" collective="false" import="true" targetId="b3d8-a821-fa00-8c48" type="selectionEntry"/>
+            <entryLink id="bfae-bea3-c47a-f989" name="Panzer III Tank Platoon (5cm)" hidden="false" collective="false" import="true" targetId="9892-987c-62b9-08c8" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="3b34-cd18-1549-fc24" name="1) Panzer III Platoon" hidden="false" collective="false" import="true" defaultSelectionEntryId="af48-441d-55e8-12ea">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="79a8-6254-c213-41ef" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e678-e99b-247b-b216" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="af48-441d-55e8-12ea" name="Panzer III Tank Platoon (5cm)" hidden="false" collective="false" import="true" targetId="9892-987c-62b9-08c8" type="selectionEntry"/>
+            <entryLink id="9346-ce13-c702-5875" name="Panzer III Tank Platoon (7.5cm)" hidden="false" collective="false" import="true" targetId="82ac-3611-246d-14a3" type="selectionEntry"/>
+            <entryLink id="74f8-36a1-1ae6-bec3" name="Panzer III (Mixed) Tank Platoon" hidden="false" collective="false" import="true" targetId="f4ec-d95d-52cf-9d06" type="selectionEntry"/>
+            <entryLink id="e077-08d8-0a85-9512" name="**Panzer III (Uparmoured) Tank Platoon" hidden="false" collective="false" import="true" targetId="b3d8-a821-fa00-8c48" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="5403-e66a-1884-a43e" name="3) Panzer III Platoon" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="edbb-57c8-4ddf-4939" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="aef4-45eb-8d50-2314" name="Panzer III Tank Platoon (5cm)" hidden="false" collective="false" import="true" targetId="9892-987c-62b9-08c8" type="selectionEntry"/>
+            <entryLink id="572f-0ab6-f978-cb7e" name="**Panzer III (Uparmoured) Tank Platoon" hidden="false" collective="false" import="true" targetId="b3d8-a821-fa00-8c48" type="selectionEntry"/>
+            <entryLink id="2051-e3e6-6421-b104" name="Panzer III Tank Platoon (7.5cm)" hidden="false" collective="false" import="true" targetId="82ac-3611-246d-14a3" type="selectionEntry"/>
+            <entryLink id="935d-f2da-36d9-77e1" name="Panzer III (Mixed) Tank Platoon" hidden="false" collective="false" import="true" targetId="f4ec-d95d-52cf-9d06" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="252b-49cc-9082-91e0" name="4) Panzer III Platoon" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="85d7-3cf5-2c9c-1eda" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="9e55-3198-03b8-72cd" name="Panzer III Tank Platoon (5cm)" hidden="false" collective="false" import="true" targetId="9892-987c-62b9-08c8" type="selectionEntry"/>
+            <entryLink id="990b-47cd-0270-e97c" name="Panzer III Tank Platoon (7.5cm)" hidden="false" collective="false" import="true" targetId="82ac-3611-246d-14a3" type="selectionEntry"/>
+            <entryLink id="056f-4648-da89-b6d8" name="**Panzer III (Uparmoured) Tank Platoon" hidden="false" collective="false" import="true" targetId="b3d8-a821-fa00-8c48" type="selectionEntry"/>
+            <entryLink id="7314-c930-48a8-b0b6" name="Panzer III (Mixed) Tank Platoon" hidden="false" collective="false" import="true" targetId="f4ec-d95d-52cf-9d06" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="e63d-6abd-3101-b594" name="***Panzer II Light Tank Platoon" hidden="false" collective="false" import="true" targetId="421b-edac-f499-d8ef" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d344-fb80-95ff-a149" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="9892-987c-62b9-08c8" name="Panzer III Tank Platoon (5cm)" hidden="false" collective="false" import="true" type="unit">
+      <infoLinks>
+        <infoLink id="4967-6342-d780-b433" name="Protected Ammo" hidden="false" targetId="ad4a-22fc-2234-7874" type="rule"/>
+        <infoLink id="868c-2ff2-8693-7aaa" name="Stormtroopers" hidden="false" targetId="5b29-2623-7f34-fc95" type="rule"/>
+        <infoLink id="d5d4-0ebd-6c19-2186" name="Third Reich" hidden="false" targetId="0d32-e61c-3e35-7b9e" type="rule"/>
+        <infoLink id="26e9-07bf-473b-e76d" name="Panzer III (MGs)" hidden="false" targetId="6b68-30d1-3bf7-9c64" type="profile"/>
+        <infoLink id="24bf-7804-e0ab-3fe8" name="Panzer III" hidden="false" targetId="d19f-9a03-5a2f-b5a3" type="profile"/>
+      </infoLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="b79f-f22a-07aa-2d33" name="Unit Size (5cm)" publicationId="b8e5-51cf-456c-eafb" hidden="false" collective="false" import="true" defaultSelectionEntryId="a298-c841-065c-685c">
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3052-6d88-e33f-fdcb" type="min"/>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af6b-c72a-752b-afaa" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="a298-c841-065c-685c" name="Panzer III (short 5cm)" hidden="false" collective="false" import="true" type="model">
+              <constraints>
+                <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7484-904f-ff5e-3c88" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="3643-ca4e-1ae3-e955" name="Panzer III (short 5cm)" hidden="false" targetId="27d6-4340-e9e0-489a" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="995a-4d67-6920-bfe4" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="ea6b-624c-dac5-2c88" name="Panzer III (long 5cm)" hidden="false" collective="false" import="true" type="model">
+              <constraints>
+                <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e325-e343-6007-06d2" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="2857-85c2-5a63-5e2c" name="Panzer III (long 5cm)" hidden="false" targetId="c348-31c6-abda-445f" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="995a-4d67-6920-bfe4" value="7.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0954-86f2-0fca-c5fa" name="Panzer IV Tank Company" hidden="false" collective="false" import="true" type="unit">
+      <selectionEntries>
+        <selectionEntry id="d4f1-437a-a1b8-e75c" name="Panzer IV Tank Company HQ" hidden="false" collective="false" import="true" type="unit">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1cd7-69b3-ad7c-0ee9" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c7e2-ca7d-e3d8-82b5" type="min"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="2e9b-0fdb-70b0-a8d1" name="Third Reich" hidden="false" targetId="0d32-e61c-3e35-7b9e" type="rule"/>
+            <infoLink id="8be3-b070-9e16-5074" name="Stormtroopers" hidden="false" targetId="5b29-2623-7f34-fc95" type="rule"/>
+            <infoLink id="7ab5-e260-446e-cac7" name="Protected Ammo" hidden="false" targetId="ad4a-22fc-2234-7874" type="rule"/>
+            <infoLink id="7176-8692-f31e-de84" name="Smoke" hidden="false" targetId="6f51-dbfe-55b0-a6d0" type="rule"/>
+            <infoLink id="1959-b672-fa3e-2ee3" name="Panzer IV" hidden="false" targetId="51f8-e73b-26df-0797" type="profile"/>
+          </infoLinks>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="04d5-4438-11dd-2761" name="Unit Size" hidden="false" collective="false" import="true" defaultSelectionEntryId="dcb8-35f6-ca8b-59cb">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cc7b-369c-8511-0301" type="min"/>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="743f-5598-4969-9273" type="max"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="dcb8-35f6-ca8b-59cb" name="Panzer IV (short 7.5cm)" hidden="false" collective="false" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2f6a-7162-8b1b-0e75" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="022e-6253-c594-049f" name="Panzer IV (short 7.5cm) Artillery" hidden="false" targetId="f01e-fa98-5ff0-a393" type="profile"/>
+                    <infoLink id="6b82-fb3f-987c-ecc9" name="Panzer IV (short 7.5cm) Direct Fire" hidden="false" targetId="e399-f101-ec82-1ecd" type="profile"/>
+                    <infoLink id="ed81-3b3a-243d-ff30" name="Panzer IV (MGs)" hidden="false" targetId="2123-1e99-f832-e359" type="profile"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="995a-4d67-6920-bfe4" value="6.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="4729-17a8-bd66-48e6" name="Panzer IV (long 7.5cm)" hidden="false" collective="false" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="57f4-6497-a9d3-c667" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="378c-7533-5c44-3812" name="Panzer IV (long 7.5cm)" hidden="false" targetId="9c83-361f-4aff-74e9" type="profile"/>
+                    <infoLink id="c2fc-2a26-2f36-c4dd" name="Panzer IV (MGs)" hidden="false" targetId="2123-1e99-f832-e359" type="profile"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="995a-4d67-6920-bfe4" value="10.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="2491-4575-5bf1-f05d" name="***Panzer IV Tank Platoon" hidden="false" collective="false" import="true" targetId="2fe8-236b-99f4-44ce" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="831f-f8f0-8696-d89f" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ad20-86b7-6765-7699" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="3749-8f41-aa22-8acd" name="***Panzer IV Tank Platoon" hidden="false" collective="false" import="true" targetId="2fe8-236b-99f4-44ce" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a45e-25a4-eb8c-a5a4" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1f3c-6278-2db6-f384" type="min"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="4bfc-04b6-b892-3b1c" name="***Panzer IV Tank Platoon" hidden="false" collective="false" import="true" targetId="2fe8-236b-99f4-44ce" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ed02-93cc-e72e-ab28" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="1603-8027-8900-3b40" name="***Panzer II Light Tank Platoon" hidden="false" collective="false" import="true" targetId="421b-edac-f499-d8ef" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1886-d5da-5b93-35ec" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2fe8-236b-99f4-44ce" name="Panzer IV Tank Platoon" hidden="false" collective="false" import="true" type="unit">
+      <infoLinks>
+        <infoLink id="1866-dbbe-0fd3-5e3b" name="Panzer IV (MGs)" hidden="false" targetId="2123-1e99-f832-e359" type="profile"/>
+        <infoLink id="b0df-c58e-d8de-994d" name="Third Reich" hidden="false" targetId="0d32-e61c-3e35-7b9e" type="rule"/>
+        <infoLink id="adba-79e3-2d3f-c6b6" name="Stormtroopers" hidden="false" targetId="5b29-2623-7f34-fc95" type="rule"/>
+        <infoLink id="b6dc-1ea7-290b-25b7" name="Protected Ammo" hidden="false" targetId="ad4a-22fc-2234-7874" type="rule"/>
+        <infoLink id="7b2d-a727-7f5a-654f" name="Smoke" hidden="false" targetId="6f51-dbfe-55b0-a6d0" type="rule"/>
+        <infoLink id="f27e-edbf-611f-263a" name="Panzer IV" hidden="false" targetId="51f8-e73b-26df-0797" type="profile"/>
+      </infoLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="d4e0-10a5-ecf5-b050" name="Unit Size" publicationId="b8e5-51cf-456c-eafb" hidden="false" collective="false" import="true" defaultSelectionEntryId="5be7-b8d0-4aa3-c912">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="404a-23cb-b827-cfe3" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fb58-1aee-81a5-e397" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="a2a7-6df4-dc3c-d6da" name="Panzer IV (long 7.5cm)" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0a81-0f2f-5ac3-5795" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="892a-44da-ee89-4cbe" name="Panzer IV (long 7.5cm)" hidden="false" targetId="9c83-361f-4aff-74e9" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="995a-4d67-6920-bfe4" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="5be7-b8d0-4aa3-c912" name="Panzer IV (short 7.5cm)" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="278b-3642-8a11-27d6" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="4ca8-557b-df39-df21" name="Panzer IV (short 7.5cm) Artillery" hidden="false" targetId="f01e-fa98-5ff0-a393" type="profile"/>
+                <infoLink id="b643-1615-97f6-952a" name="Panzer IV (short 7.5cm) Direct Fire" hidden="false" targetId="e399-f101-ec82-1ecd" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="995a-4d67-6920-bfe4" value="6.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5275-a14c-ea45-9444" name="Reconnaissance Support Unit" hidden="false" collective="false" import="true" type="unit">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="1a55-0497-f471-4d4e" name="Type" hidden="false" collective="false" import="true" defaultSelectionEntryId="8a77-172f-06d4-3ad2">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d3d1-d68f-8e28-866b" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="536b-6c99-5b95-43d8" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="9fa6-2cc9-7b4b-326c" name="Sd Kfz 231 Heavy Scout Troop" hidden="false" collective="false" import="true" targetId="8a59-b461-9bd1-6401" type="selectionEntry"/>
+            <entryLink id="8a77-172f-06d4-3ad2" name="Sd Kfz 221 &amp; 222 Light Scout Troop" hidden="false" collective="false" import="true" targetId="1805-7cf8-8b3f-a2df" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e176-eaf3-6806-dfb4" name="Sd Kfz 10/4 Light AA Platoon" hidden="false" collective="false" import="true" type="unit">
+      <infoLinks>
+        <infoLink id="fc48-09d7-9c96-8270" name="Dedicated AA" hidden="false" targetId="f4bc-db53-7a0d-0aeb" type="rule"/>
+        <infoLink id="98af-5e8b-06b2-5acb" name="Sd Kfz 10/4 (2cm) [Weapon]" hidden="false" targetId="12cd-6760-0e39-16c0" type="profile"/>
+        <infoLink id="57c7-bab0-6685-9ea9" name="Stormtroopers" hidden="false" targetId="5b29-2623-7f34-fc95" type="rule"/>
+        <infoLink id="9be3-ddb6-5abb-4bc6" name="Sd Kfz 10/4 (2cm)" hidden="false" targetId="9e0f-d18b-6774-05a6" type="profile"/>
+        <infoLink id="4ff4-f9a0-a615-eed7" name="Third Reich" hidden="false" targetId="0d32-e61c-3e35-7b9e" type="rule"/>
+      </infoLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="c313-0821-5d47-6587" name="Unit Size" publicationId="b8e5-51cf-456c-eafb" hidden="false" collective="false" import="true" defaultSelectionEntryId="6903-cfd2-b747-28b9">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9909-df8d-89f6-1104" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5141-786b-6998-942f" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="79a3-c418-b28f-722e" name="4x Sd Kfz 10/4 (2cm)" hidden="false" collective="false" import="true" type="upgrade">
+              <costs>
+                <cost name="pts" typeId="995a-4d67-6920-bfe4" value="8.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="6903-cfd2-b747-28b9" name="2x Sd Kfz 10/4 (2cm)" hidden="false" collective="false" import="true" type="upgrade">
+              <costs>
+                <cost name="pts" typeId="995a-4d67-6920-bfe4" value="4.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="c519-dd27-3a67-0b10" name="3x Sd Kfz 10/4 (2cm)" hidden="false" collective="false" import="true" type="upgrade">
+              <costs>
+                <cost name="pts" typeId="995a-4d67-6920-bfe4" value="6.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="421b-edac-f499-d8ef" name="Panzer II Light Tank Platoon" hidden="false" collective="false" import="true" type="unit">
+      <infoLinks>
+        <infoLink id="a5c9-07f2-fe03-0999" name="Panzer II (MG)" hidden="false" targetId="85a8-b4f2-1c62-0ec0" type="profile"/>
+        <infoLink id="29bc-0b10-8062-b485" name="Third Reich" hidden="false" targetId="0d32-e61c-3e35-7b9e" type="rule"/>
+        <infoLink id="1d64-3bf7-0ed3-adc9" name="Stormtroopers" hidden="false" targetId="5b29-2623-7f34-fc95" type="rule"/>
+        <infoLink id="ff04-fb90-02a5-39dc" name="Spearhead" hidden="false" targetId="70fc-43a3-1ed1-1b01" type="rule"/>
+        <infoLink id="088b-abbb-f214-0595" name="Panzer II (2cm)" hidden="false" targetId="f17d-c1b0-c078-5874" type="profile"/>
+        <infoLink id="91bc-3a81-157f-5e83" name="Panzer II (2cm) [Weapon]" hidden="false" targetId="9fec-a2fe-7262-a9fc" type="profile"/>
+      </infoLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="6d26-e783-7b18-4cec" name="Unit Size" publicationId="b8e5-51cf-456c-eafb" hidden="false" collective="false" import="true" defaultSelectionEntryId="11ff-5796-5e76-0ed0">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ef98-f1c3-d6fe-c90a" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8ca8-cddf-1d11-c018" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="7208-0516-7e95-3f8a" name="5x Panzer II (2cm)" hidden="false" collective="false" import="true" type="upgrade">
+              <costs>
+                <cost name="pts" typeId="995a-4d67-6920-bfe4" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="0a96-9254-9687-fec1" name="4x Panzer II (2cm)" hidden="false" collective="false" import="true" type="upgrade">
+              <costs>
+                <cost name="pts" typeId="995a-4d67-6920-bfe4" value="8.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="11ff-5796-5e76-0ed0" name="3x Panzer II (2cm)" hidden="false" collective="false" import="true" type="upgrade">
+              <costs>
+                <cost name="pts" typeId="995a-4d67-6920-bfe4" value="6.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b3d8-a821-fa00-8c48" name="Panzer III (Uparmoured) Tank Platoon" hidden="false" collective="false" import="true" type="unit">
+      <infoLinks>
+        <infoLink id="3cbe-dbbd-422a-6939" name="Panzer III (MGs)" hidden="false" targetId="6b68-30d1-3bf7-9c64" type="profile"/>
+        <infoLink id="bfce-aaf6-8866-58fe" name="Third Reich" hidden="false" targetId="0d32-e61c-3e35-7b9e" type="rule"/>
+        <infoLink id="14de-fcfa-c028-7a4c" name="Stormtroopers" hidden="false" targetId="5b29-2623-7f34-fc95" type="rule"/>
+        <infoLink id="b4d1-a4ca-a989-fb25" name="Protected Ammo" hidden="false" targetId="ad4a-22fc-2234-7874" type="rule"/>
+        <infoLink id="c3ec-060d-b805-8b0e" name="Panzer III (uparmoured)" hidden="false" targetId="c1d6-72c3-6ff0-b7ad" type="profile"/>
+        <infoLink id="2355-dfc6-d251-b8ec" name="Panzer III (long 5cm)" hidden="false" targetId="c348-31c6-abda-445f" type="profile"/>
+      </infoLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="b77e-976f-e6e2-75d1" name="Unit Size (Uparmoured)" publicationId="b8e5-51cf-456c-eafb" hidden="false" collective="false" import="true" defaultSelectionEntryId="4dc3-9ae0-0dc1-025c">
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b887-1dca-59fa-3a38" type="min"/>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="91cd-e1ec-676e-77a3" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="4dc3-9ae0-0dc1-025c" name="Panzer III (uparmoured)" hidden="false" collective="false" import="true" type="model">
+              <constraints>
+                <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="50a6-cb48-b7ec-7749" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="995a-4d67-6920-bfe4" value="8.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f4ec-d95d-52cf-9d06" name="Panzer III (Mixed) Tank Platoon" hidden="false" collective="false" import="true" type="unit">
+      <infoLinks>
+        <infoLink id="be17-6071-7793-c8dc" name="Panzer III (MGs)" hidden="false" targetId="6b68-30d1-3bf7-9c64" type="profile"/>
+        <infoLink id="89e2-8cfe-3230-f940" name="Third Reich" hidden="false" targetId="0d32-e61c-3e35-7b9e" type="rule"/>
+        <infoLink id="5e0b-9409-64c7-8001" name="Stormtroopers" hidden="false" targetId="5b29-2623-7f34-fc95" type="rule"/>
+        <infoLink id="a18c-b360-f89e-4531" name="Protected Ammo" hidden="false" targetId="ad4a-22fc-2234-7874" type="rule"/>
+      </infoLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="9554-b59f-ecbb-1b56" name="Unit Size (Mixed)" publicationId="b8e5-51cf-456c-eafb" hidden="false" collective="false" import="true" defaultSelectionEntryId="b30c-de2a-c177-a4de">
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a63a-f73b-403b-3b72" type="min"/>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e92d-1bb5-2aec-4c11" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="0f19-ad1a-4abc-b09c" name="7.5cm" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5d75-b944-3fdc-a8fc" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="ef59-df46-f1bb-3161" name="Panzer III (7.5cm)" hidden="false" targetId="e95a-01e2-de0f-70be" type="profile"/>
+                <infoLink id="bda8-c1b9-3746-7e95" name="Panzer III" hidden="false" targetId="d19f-9a03-5a2f-b5a3" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="995a-4d67-6920-bfe4" value="8.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="8d6a-d3ff-2b22-3536" name="Long 5cm" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ffda-41f2-9b81-5de3" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="8067-4ee4-6921-ad21" name="Panzer III (long 5cm)" hidden="false" targetId="c348-31c6-abda-445f" type="profile"/>
+                <infoLink id="fd2b-8a49-03b7-fc67" name="Panzer III" hidden="false" targetId="d19f-9a03-5a2f-b5a3" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="995a-4d67-6920-bfe4" value="7.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="b30c-de2a-c177-a4de" name="Short 5cm" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6d64-40af-ed01-7618" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="0c21-fb11-32e4-6001" name="Panzer III (short 5cm)" hidden="false" targetId="27d6-4340-e9e0-489a" type="profile"/>
+                <infoLink id="60c4-f4d1-b0ee-b237" name="Panzer III" hidden="false" targetId="d19f-9a03-5a2f-b5a3" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="995a-4d67-6920-bfe4" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="8a45-5de4-f7f9-f94a" name="Uparmour Long 5cm" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="88ee-bbb0-3038-4d83" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="401f-f133-35db-93c2" name="Panzer III (uparmoured)" hidden="false" targetId="c1d6-72c3-6ff0-b7ad" type="profile"/>
+                <infoLink id="6be7-ae9e-8ccd-e4f9" name="Panzer III (long 5cm)" hidden="false" targetId="c348-31c6-abda-445f" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="995a-4d67-6920-bfe4" value="8.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="27ab-4f27-5703-a40f" name="Command Cards" hidden="false" collective="false" import="true" type="unit">
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4bd5-7601-ac8e-e1ae" type="max"/>
+      </constraints>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="5e1d-d1cd-d23b-226e" name="Basic Command Cards" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4826-0bf5-c42c-939b" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="d29f-866a-c610-f7d2" name="Brandenburgers" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="97ae-e5b1-1571-11fd" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="fb54-5478-adc9-cd78" name="Brandenburgers" hidden="false" typeId="94ea-9234-fbd5-3352" typeName="Command Card [Abridged]">
+                  <characteristics>
+                    <characteristic name="Details" typeId="1944-fd09-973e-5731">When your opponents would first roll for Air Support, they automatically fail to receive Air Support for that turn.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="995a-4d67-6920-bfe4" value="1.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="090c-ce78-a8ed-6e4d" name="Diversionary Tactics" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4eb5-728a-2f80-0097" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="7094-0194-c2df-9bdb" name="Diversionary Tactics" hidden="false" typeId="94ea-9234-fbd5-3352" typeName="Command Card [Abridged]">
+                  <characteristics>
+                    <characteristic name="Details" typeId="1944-fd09-973e-5731">At the start of a game, after deployment, reposition one of your opponent&apos;s Ranged In markers up to 6&quot;/15cm in any direction.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="995a-4d67-6920-bfe4" value="1.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="529e-ab52-137a-87e7" name="Dummy Minefield" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9bfe-2608-f1fa-9c34" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="14c4-57de-0371-d587" name="Dummy Minefield" hidden="false" typeId="94ea-9234-fbd5-3352" typeName="Command Card [Abridged]">
+                  <characteristics>
+                    <characteristic name="Details" typeId="1944-fd09-973e-5731">If this mission has Minefields, after Deployment, you may redeploy a Minefield marker anywhere outside your opponent&apos;s deployment area.
+
+In Missions without Minefields, you may deploy a Minefield marker anywhere outside your opponent&apos;s deployment area before placing Objectives.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="995a-4d67-6920-bfe4" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="3470-32ea-7bbb-a3e6" name="Erwin Rommel" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3ead-1c22-ecef-6218" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="c3ac-80f3-e550-32c0" name="Erwin Rommel" hidden="false" typeId="94ea-9234-fbd5-3352" typeName="Command Card [Abridged]">
+                  <characteristics>
+                    <characteristic name="Details" typeId="1944-fd09-973e-5731">All of your Formation Commanders have their Command Leadership range increase from 6&quot;/15cm to 8&quot;/20cm.
+
+If you win the game, you gain one extra Victory Point; if you lose the game, you lose one extra Victory Point.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="995a-4d67-6920-bfe4" value="6.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="e03b-446a-ddca-f607" name="Pure Luck" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="85fb-b13b-74c6-c3f1" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="577e-b6d7-e892-6448" name="Pure Luck" hidden="false" typeId="94ea-9234-fbd5-3352" typeName="Command Card [Abridged]">
+                  <characteristics>
+                    <characteristic name="Details" typeId="1944-fd09-973e-5731"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="995a-4d67-6920-bfe4" value="1.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1805-7cf8-8b3f-a2df" name="Sd Kfz 221 &amp; 222 Light Scout Troop" publicationId="b8e5-51cf-456c-eafb" hidden="false" collective="false" import="true" type="unit">
+      <infoLinks>
+        <infoLink id="f689-866b-49d0-d750" name="Sd Kfz 222 &amp; 221 [Unit]" hidden="false" targetId="b9c5-805b-4d8e-f2e2" type="profile"/>
+        <infoLink id="ec89-f747-d6a1-5aa8" name="Stormtroopers" hidden="false" targetId="5b29-2623-7f34-fc95" type="rule"/>
+        <infoLink id="be50-f832-770f-5c71" name="Sd Kfz 222 &amp; 221 (MG)" hidden="false" targetId="c190-2257-2267-8970" type="profile"/>
+        <infoLink id="52e5-b6c6-a1b9-2cc3" name="Spearhead" hidden="false" targetId="70fc-43a3-1ed1-1b01" type="rule"/>
+        <infoLink id="ba39-e185-5d56-eaff" name="Sd Kfz 222 (2cm)" hidden="false" targetId="e83c-fc97-c1fb-9577" type="profile"/>
+        <infoLink id="d923-b655-dcc6-24d3" name="Scout" hidden="false" targetId="967a-118e-dc01-7e0b" type="rule"/>
+        <infoLink id="4be8-c030-2106-1bfa" name="Self-Defence AA" hidden="false" targetId="6c0b-8d39-70b6-9d1c" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="f52d-8119-5f73-9247" name="New CategoryLink" hidden="false" targetId="9be3-4dab-91f0-f7c5" primary="true"/>
+      </categoryLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="1247-40a6-5277-7ae7" name="Unit Size" hidden="false" collective="false" import="true" defaultSelectionEntryId="e96a-e674-baf6-32c7">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af8d-491b-2e72-924e" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dbcb-b3f1-d2ea-058e" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="e96a-e674-baf6-32c7" name="1) 2x Sd Kfz 222, 1x Sd Kfz 221 (MG)" hidden="false" collective="false" import="true" type="model">
+              <selectionEntries>
+                <selectionEntry id="929a-5eb0-cd51-7083" name="2x Sd Kfz 222 (2cm)" hidden="false" collective="false" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a412-fbdd-47a9-4e37" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5bfc-82ad-c6c2-162e" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="523e-e674-3b57-0dbc" name="1x Sd Kfz 221 (MG)" hidden="false" collective="false" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7349-264f-4f0a-1452" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="400e-abf1-fba9-9669" type="min"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <costs>
+                <cost name="pts" typeId="995a-4d67-6920-bfe4" value="2.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="4c4a-3d93-7f7a-7696" name="2) 2x Sd Kfz 222, 1x Sd Kfz 221 (2.8cm)" hidden="false" collective="false" import="true" type="model">
+              <selectionEntries>
+                <selectionEntry id="7f93-5a1e-0814-38af" name="2x Sd Kfz 222 (2cm)" hidden="false" collective="false" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1cf6-2bde-6a3d-a00a" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="24db-8ee1-140b-8c0e" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="33be-094a-33af-456f" name="1x Sd Kfz 221 (2.8cm)" hidden="false" collective="false" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cc15-5d87-bd24-8a77" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dbf3-fce9-fb8e-e0f3" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="092a-65e1-c37f-1e60" name="Sd Kfz 221 (2.8cm)" hidden="false" targetId="269b-6001-8015-8bcc" type="profile"/>
+                    <infoLink id="d77f-df14-f302-3f1a" name="No HE" hidden="false" targetId="b000-d0f1-08fd-0d43" type="rule"/>
+                    <infoLink id="f8bf-1ce3-9426-17d9" name="Slow Firing" hidden="false" targetId="e215-d5bf-83ce-606a" type="rule"/>
+                    <infoLink id="e122-5e73-3f39-5c1a" name="Forward Firing" hidden="false" targetId="fa9d-68f6-57d9-dc5d" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <costs>
+                <cost name="pts" typeId="995a-4d67-6920-bfe4" value="2.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="295a-1a42-0576-6463" name="3) 2x Sd Kfz 222, 2x Sd Kfz 221 (MG)" hidden="false" collective="false" import="true" type="model">
+              <selectionEntries>
+                <selectionEntry id="f642-9be6-26ca-e2fc" name="2x Sd Kfz 222 (2cm)" hidden="false" collective="false" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3bf2-ed48-c8ba-bd13" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="920c-44d6-8964-c8f3" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="b413-eb05-4a35-f0a0" name="2x Sd Kfz 221 (MG)" hidden="false" collective="false" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f2d7-2767-4764-9f7c" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ab82-c54c-fe08-bbc3" type="min"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <costs>
+                <cost name="pts" typeId="995a-4d67-6920-bfe4" value="3.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="77d1-50d2-986e-914c" name="4) 2x Sd Kfz 222, 2x Sd Kfz 221 (2.8cm)" hidden="false" collective="false" import="true" type="model">
+              <selectionEntries>
+                <selectionEntry id="7dc6-367a-8f10-a9cf" name="2x Sd Kfz 222 (2cm)" hidden="false" collective="false" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e183-fde4-1283-4ffb" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7626-8b29-f62d-3741" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="faaa-fd1d-2670-1fb1" name="2x Sd Kfz 221 (2.8cm)" hidden="false" collective="false" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5230-a823-0e00-04cd" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9c10-512e-a708-8529" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="fbc0-19bd-ac50-57ed" name="Sd Kfz 221 (2.8cm)" hidden="false" targetId="269b-6001-8015-8bcc" type="profile"/>
+                    <infoLink id="6b62-2792-767e-4ad1" name="No HE" hidden="false" targetId="b000-d0f1-08fd-0d43" type="rule"/>
+                    <infoLink id="89ab-90cb-70ac-ef5c" name="Slow Firing" hidden="false" targetId="e215-d5bf-83ce-606a" type="rule"/>
+                    <infoLink id="e577-4227-bf91-aee6" name="Forward Firing" hidden="false" targetId="fa9d-68f6-57d9-dc5d" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <costs>
+                <cost name="pts" typeId="995a-4d67-6920-bfe4" value="3.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="8a90-b0c3-25f6-e31a" name="5) 2x Sd Kfz 222, 2x Sd Kfz 221 (2.8cm / MG)" hidden="false" collective="false" import="true" type="model">
+              <selectionEntries>
+                <selectionEntry id="3c71-25ee-7265-11e5" name="2x Sd Kfz 222 (2cm)" hidden="false" collective="false" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d970-39d8-caee-e0bb" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="52ae-bc61-1727-69b7" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="c015-6914-13f2-9639" name="1x Sd Kfz 221 (2.8cm)" hidden="false" collective="false" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a387-9806-6aed-1353" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f75e-dfc0-7e76-8694" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="3b32-b82c-a55b-59da" name="Sd Kfz 221 (2.8cm)" hidden="false" targetId="269b-6001-8015-8bcc" type="profile"/>
+                    <infoLink id="29fc-829e-dd01-d4cf" name="No HE" hidden="false" targetId="b000-d0f1-08fd-0d43" type="rule"/>
+                    <infoLink id="f75f-7af7-b80a-2f5f" name="Slow Firing" hidden="false" targetId="e215-d5bf-83ce-606a" type="rule"/>
+                    <infoLink id="fa43-88c2-989c-cb43" name="Forward Firing" hidden="false" targetId="fa9d-68f6-57d9-dc5d" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="2a5c-6826-52c1-20db" name="1x Sd Kfz 221 (MG)" hidden="false" collective="false" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3003-6115-c30c-0640" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="62d3-a247-f9e7-83fb" type="min"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <costs>
+                <cost name="pts" typeId="995a-4d67-6920-bfe4" value="3.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="8a59-b461-9bd1-6401" name="Sd Kfz 231 Heavy Scout Troop" publicationId="b8e5-51cf-456c-eafb" hidden="false" collective="false" import="true" type="unit">
+      <infoLinks>
+        <infoLink id="019e-54c0-417b-911f" name="Sd Kfz 231 (2cm)" hidden="false" targetId="0656-168a-fde7-645a" type="profile"/>
+        <infoLink id="100c-d688-401a-de1f" name="Stormtroopers" hidden="false" targetId="5b29-2623-7f34-fc95" type="rule"/>
+        <infoLink id="10e5-9f24-f059-027c" name="Sd Kfz 231 (2cm) [Weapon]" hidden="false" targetId="4506-81fb-f1a0-3897" type="profile"/>
+        <infoLink id="54fb-d782-2087-f0c2" name="Spearhead" hidden="false" targetId="70fc-43a3-1ed1-1b01" type="rule"/>
+        <infoLink id="c904-b2f1-a1ed-e883" name="Sd Kfz 231 (MG)" hidden="false" targetId="a039-177e-54a8-ff1b" type="profile"/>
+        <infoLink id="478c-cd6d-ecda-6efe" name="Scout" hidden="false" targetId="967a-118e-dc01-7e0b" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="f17c-6da5-be32-d792" name="New CategoryLink" hidden="false" targetId="9be3-4dab-91f0-f7c5" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="d864-e106-d41b-c478" name="2x Sd Kfz 231 (2cm)" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ba99-cd0e-e8c8-e35a" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="57c4-a7ce-00bf-8996" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="995a-4d67-6920-bfe4" value="2.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="82ac-3611-246d-14a3" name="Panzer III Tank Platoon (7.5cm)" hidden="false" collective="false" import="true" type="unit">
+      <infoLinks>
+        <infoLink id="e02f-e01d-9bb3-d8c4" name="Protected Ammo" hidden="false" targetId="ad4a-22fc-2234-7874" type="rule"/>
+        <infoLink id="91c7-c322-6828-145b" name="Stormtroopers" hidden="false" targetId="5b29-2623-7f34-fc95" type="rule"/>
+        <infoLink id="0a22-2398-7bf7-ad22" name="Third Reich" hidden="false" targetId="0d32-e61c-3e35-7b9e" type="rule"/>
+        <infoLink id="20be-fdab-ab35-0a84" name="Panzer III (MGs)" hidden="false" targetId="6b68-30d1-3bf7-9c64" type="profile"/>
+        <infoLink id="8778-80a3-4eb1-0061" name="Panzer III" hidden="false" targetId="d19f-9a03-5a2f-b5a3" type="profile"/>
+      </infoLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="e37c-85af-834a-7ead" name="Unit Size (7.5cm)" publicationId="b8e5-51cf-456c-eafb" hidden="false" collective="false" import="true" defaultSelectionEntryId="5cfc-8824-f47d-7462">
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="28c8-c91b-3bde-f423" type="max"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bc5b-a7e7-7410-93b7" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="5cfc-8824-f47d-7462" name="Panzer III (7.5cm)" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3e65-5415-28ba-82ac" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="f26a-6bfe-4016-43c5" name="Panzer III (7.5cm)" hidden="false" targetId="e95a-01e2-de0f-70be" type="profile"/>
+                <infoLink id="2690-1148-0a3a-7970" name="HEAT" hidden="false" targetId="9a14-019a-eb63-0b40" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="995a-4d67-6920-bfe4" value="8.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a81a-fd1d-97b4-1a73" name="[INCOMPLETE] 90th Light Rifle Company" hidden="true" collective="false" import="true" type="unit">
+      <costs>
+        <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4a4d-6e94-b13e-dcec" name="Tiger Tank or Diana Tank-Hunter Platoon" hidden="false" collective="false" import="true" type="unit">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="4acb-7f99-668c-94e5" name="Type" hidden="false" collective="false" import="true" defaultSelectionEntryId="5cdd-59d1-f32e-d241">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="99ae-0e90-5681-5bb0" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1af2-12dd-310c-01d5" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="5cdd-59d1-f32e-d241" name="[S] Tiger Heavy Tank Platoon" hidden="false" collective="false" import="true" type="unit">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="26f0-7f6a-90c2-64ca" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="3b76-5d5e-59e1-022a" name="Tiger (8.8cm) [Unit]" hidden="false" targetId="6184-56a0-7f08-ca58" type="profile"/>
+                <infoLink id="8bcb-dbc2-ef2b-73cb" name="Tiger (8.8cm) [Weapon]" hidden="false" targetId="ed37-ed58-11d6-dd04" type="profile"/>
+                <infoLink id="6e9c-1f6b-2777-85c9" name="Tiger (MGs)" hidden="false" targetId="e920-43c0-80c1-e94c" type="profile"/>
+                <infoLink id="866c-f6a4-91a7-4e23" name="Stormtroopers" hidden="false" targetId="5b29-2623-7f34-fc95" type="rule"/>
+                <infoLink id="5596-175b-cb10-7c90" name="Escort Tanks" hidden="false" targetId="3ee0-bd48-245e-56a8" type="rule"/>
+                <infoLink id="61c4-aea6-4e5c-c40f" name="Tiger Ace" hidden="false" targetId="d58a-ba48-0bc7-b673" type="rule"/>
+              </infoLinks>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="65f6-096d-5aab-bf99" name="Unit Size" hidden="false" collective="false" import="true" defaultSelectionEntryId="bb00-b9ad-5a28-7aac">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="44f5-0c39-6f25-9cd9" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c622-af45-3ef5-57a4" type="max"/>
+                  </constraints>
+                  <selectionEntries>
+                    <selectionEntry id="f863-23a1-02dd-f83b" name="2x Tiger (8.8cm)" hidden="false" collective="false" import="true" type="model">
+                      <costs>
+                        <cost name="pts" typeId="995a-4d67-6920-bfe4" value="58.0"/>
+                      </costs>
+                    </selectionEntry>
+                    <selectionEntry id="bb00-b9ad-5a28-7aac" name="1x Tiger (8.8cm)" hidden="false" collective="false" import="true" type="model">
+                      <costs>
+                        <cost name="pts" typeId="995a-4d67-6920-bfe4" value="29.0"/>
+                      </costs>
+                    </selectionEntry>
+                  </selectionEntries>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="fe43-1f6f-1b88-3fdd" name="Escort Tanks" hidden="false" collective="false" import="true">
+                  <modifiers>
+                    <modifier type="set" field="ee81-51e8-4130-f678" value="2.0">
+                      <conditions>
+                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f863-23a1-02dd-f83b" type="greaterThan"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="set" field="ee81-51e8-4130-f678" value="1.0">
+                      <conditions>
+                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bb00-b9ad-5a28-7aac" type="greaterThan"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ee81-51e8-4130-f678" type="max"/>
+                  </constraints>
+                  <selectionEntries>
+                    <selectionEntry id="4f90-567f-a09c-2c12" name="Panzer III (7.5cm)" hidden="false" collective="false" import="true" type="upgrade">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bd2f-e450-205e-62fa" type="max"/>
+                      </constraints>
+                      <infoLinks>
+                        <infoLink id="7aa1-e7d2-42ec-e82e" name="Panzer III (7.5cm)" hidden="false" targetId="e95a-01e2-de0f-70be" type="profile"/>
+                        <infoLink id="a900-c927-ef56-5463" name="HEAT" hidden="false" targetId="9a14-019a-eb63-0b40" type="rule"/>
+                        <infoLink id="94c4-95b9-8df8-d40e" name="Panzer III" hidden="false" targetId="d19f-9a03-5a2f-b5a3" type="profile"/>
+                        <infoLink id="c811-53bb-aa27-0a32" name="Panzer III (MGs)" hidden="false" targetId="6b68-30d1-3bf7-9c64" type="profile"/>
+                      </infoLinks>
+                      <costs>
+                        <cost name="pts" typeId="995a-4d67-6920-bfe4" value="8.0"/>
+                      </costs>
+                    </selectionEntry>
+                    <selectionEntry id="6ca4-8132-08a7-b9a6" name="Panzer III (Uparmoured)" hidden="false" collective="false" import="true" type="upgrade">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="860a-eb4f-5f91-c5ae" type="max"/>
+                      </constraints>
+                      <infoLinks>
+                        <infoLink id="af58-f56d-d5a4-8eb9" name="Panzer III (uparmoured)" hidden="false" targetId="c1d6-72c3-6ff0-b7ad" type="profile"/>
+                        <infoLink id="5749-147c-06fd-078e" name="Panzer III (long 5cm)" hidden="false" targetId="c348-31c6-abda-445f" type="profile"/>
+                        <infoLink id="3e5c-aad1-49ea-0413" name="Panzer III (MGs)" hidden="false" targetId="6b68-30d1-3bf7-9c64" type="profile"/>
+                      </infoLinks>
+                      <costs>
+                        <cost name="pts" typeId="995a-4d67-6920-bfe4" value="8.0"/>
+                      </costs>
+                    </selectionEntry>
+                  </selectionEntries>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="0d24-bcd7-3aac-71c9" name="Tiger Command Cards" hidden="false" collective="false" import="true">
+                  <selectionEntries>
+                    <selectionEntry id="c8de-c804-7e37-34d3" name="Schnell" hidden="false" collective="false" import="true" type="upgrade">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="52cd-ae2b-2514-efb8" type="max"/>
+                      </constraints>
+                      <profiles>
+                        <profile id="d710-6ec3-f676-c1b1" name="Schnell" hidden="false" typeId="94ea-9234-fbd5-3352" typeName="Command Card [Abridged]">
+                          <characteristics>
+                            <characteristic name="Details" typeId="1944-fd09-973e-5731">This unit passes Blitz moves on 2+.</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                      <costs>
+                        <cost name="pts" typeId="995a-4d67-6920-bfe4" value="4.0"/>
+                      </costs>
+                    </selectionEntry>
+                    <selectionEntry id="7ab5-c996-2a81-1420" name="Rapid Fire" hidden="false" collective="false" import="true" type="upgrade">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="da7c-d18f-1853-854e" type="max"/>
+                      </constraints>
+                      <profiles>
+                        <profile id="2c71-8e39-1a5b-51c2" name="Rapid Fire" hidden="false" typeId="94ea-9234-fbd5-3352" typeName="Command Card [Abridged]">
+                          <characteristics>
+                            <characteristic name="Details" typeId="1944-fd09-973e-5731">The Unit Leader&apos;s Tiger tank has Halted ROF 3 with its 8.8cm gun.</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                      <costs>
+                        <cost name="pts" typeId="995a-4d67-6920-bfe4" value="8.0"/>
+                      </costs>
+                    </selectionEntry>
+                    <selectionEntry id="827b-a685-5082-d7eb" name="Deadly Gunner" hidden="false" collective="false" import="true" type="upgrade">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b389-7a73-fdc6-d07e" type="max"/>
+                      </constraints>
+                      <profiles>
+                        <profile id="884e-4ad8-747d-0a23" name="Deadly Gunner" hidden="false" typeId="94ea-9234-fbd5-3352" typeName="Command Card [Abridged]">
+                          <characteristics>
+                            <characteristic name="Details" typeId="1944-fd09-973e-5731">The Unit Leader may re-roll one failed Firepower Test during the Shooting Step.</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                      <costs>
+                        <cost name="pts" typeId="995a-4d67-6920-bfe4" value="4.0"/>
+                      </costs>
+                    </selectionEntry>
+                    <selectionEntry id="a7aa-09b6-eb5d-2638" name="Clever Hans" hidden="false" collective="false" import="true" type="upgrade">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="628c-11ca-24b9-577b" type="max"/>
+                      </constraints>
+                      <profiles>
+                        <profile id="671e-6c80-a249-2802" name="Clever Hans" hidden="false" typeId="94ea-9234-fbd5-3352" typeName="Command Card [Abridged]">
+                          <characteristics>
+                            <characteristic name="Details" typeId="1944-fd09-973e-5731">Tiger tanks in this Unit pass Cross tests on 2+.</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                      <costs>
+                        <cost name="pts" typeId="995a-4d67-6920-bfe4" value="3.0"/>
+                      </costs>
+                    </selectionEntry>
+                  </selectionEntries>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <costs>
+                <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <entryLinks>
+            <entryLink id="649a-9b07-1107-5d3e" name="[INCOMPLETE] Diana Tank-hunter Platoon" hidden="false" collective="false" import="true" targetId="d3c7-0925-b18f-12f2" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="d3c7-0925-b18f-12f2" name="[INCOMPLETE] Diana Tank-hunter Platoon" hidden="true" collective="false" import="true" type="unit">
+      <profiles>
+        <profile id="c6c9-984d-2b2b-ea3a" name="Diana Tank-hunter" hidden="false" typeId="55ec-3ef5-ca51-e647" typeName="Tank Unit">
+          <characteristics>
+            <characteristic name="Motivation" typeId="046a-7f27-8072-dedb">4+ / 6 Counterattack / 3+ Last Stand</characteristic>
+            <characteristic name="Skill" typeId="6334-745a-f712-a0aa">3+ / 5+ Assault</characteristic>
+            <characteristic name="Is Hit On" typeId="3931-565d-e382-fda5">4+</characteristic>
+            <characteristic name="Armour Front" typeId="b88a-3ca6-9b40-ff73">0</characteristic>
+            <characteristic name="Armour Side &amp; Rear" typeId="3712-51b3-aae3-94bd">0</characteristic>
+            <characteristic name="Armour Top" typeId="f551-1392-03e8-967d">0</characteristic>
+            <characteristic name="Tactical" typeId="ea9a-bf7d-68c5-e2d7">8&quot;/20cm</characteristic>
+            <characteristic name="Terrain Dash" typeId="f7f4-9e66-c9ed-034b">10&quot;/25cm</characteristic>
+            <characteristic name="Cross Country Dash" typeId="f73b-6fcf-b0d1-fde4">14&quot;/35cm</characteristic>
+            <characteristic name="Road Dash" typeId="b5b1-c829-470a-af62">24&quot;/60cm</characteristic>
+            <characteristic name="Cross" typeId="8be2-d5b6-ec4a-76d9">4+</characteristic>
+            <characteristic name="Notes" typeId="33d6-6375-9564-9985"/>
+          </characteristics>
+        </profile>
+        <profile id="89b2-5ba8-b50c-e8c9" name="Diana (7.62cm)" hidden="false" typeId="33b6-a72a-2bd8-2565" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="c2e5-4990-8105-f793">28&quot;/70cm</characteristic>
+            <characteristic name="Halted ROF" typeId="7f6e-6f8f-5f15-6e9d">2</characteristic>
+            <characteristic name="Moving ROF" typeId="f78e-b583-b3a5-754a">1</characteristic>
+            <characteristic name="Anti-Tank" typeId="f57e-fa10-d0f9-e2dd">11</characteristic>
+            <characteristic name="Firepower" typeId="9cf3-a34f-60d9-1309">3+</characteristic>
+            <characteristic name="Notes" typeId="d939-5084-e654-44c6">Forward Firing</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="34a1-adf9-d7c0-911d" name="Forward Firing" hidden="false" targetId="fa9d-68f6-57d9-dc5d" type="rule"/>
+        <infoLink id="612e-4d95-4793-cee4" name="Third Reich" hidden="false" targetId="0d32-e61c-3e35-7b9e" type="rule"/>
+      </infoLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="0671-260b-0420-b010" name="Unit Size" hidden="false" collective="false" import="true" defaultSelectionEntryId="65f5-3331-b11d-e6ed">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c8f6-af13-73c7-6a44" type="min"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cf75-8741-d060-ff80" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="65f5-3331-b11d-e6ed" name="Diana" hidden="false" collective="false" import="true" type="model">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="72a9-3894-8c28-6727" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="995a-4d67-6920-bfe4" value="3.5"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b39f-8fd8-5ccd-6bf6" name="[INCOMPLETE] 15cm Bison Infantry Gun Platoon" hidden="true" collective="false" import="true" type="unit">
+      <profiles>
+        <profile id="0763-9942-88db-0d61" name="Bison Infantry Gun Platoon" hidden="false" typeId="55ec-3ef5-ca51-e647" typeName="Tank Unit">
+          <characteristics>
+            <characteristic name="Motivation" typeId="046a-7f27-8072-dedb">4+ / 6 Counterattack / 3+ Last Stand</characteristic>
+            <characteristic name="Skill" typeId="6334-745a-f712-a0aa">3+ / 5+ Assault</characteristic>
+            <characteristic name="Is Hit On" typeId="3931-565d-e382-fda5">4+</characteristic>
+            <characteristic name="Armour Front" typeId="b88a-3ca6-9b40-ff73">2</characteristic>
+            <characteristic name="Armour Side &amp; Rear" typeId="3712-51b3-aae3-94bd">2</characteristic>
+            <characteristic name="Armour Top" typeId="f551-1392-03e8-967d">0</characteristic>
+            <characteristic name="Tactical" typeId="ea9a-bf7d-68c5-e2d7">10&quot;/25cm</characteristic>
+            <characteristic name="Terrain Dash" typeId="f7f4-9e66-c9ed-034b">12&quot;/30cm</characteristic>
+            <characteristic name="Cross Country Dash" typeId="f73b-6fcf-b0d1-fde4">16&quot;/40cm</characteristic>
+            <characteristic name="Road Dash" typeId="b5b1-c829-470a-af62">18&quot;/45cm</characteristic>
+            <characteristic name="Cross" typeId="8be2-d5b6-ec4a-76d9">3+</characteristic>
+            <characteristic name="Notes" typeId="33d6-6375-9564-9985"/>
+          </characteristics>
+        </profile>
+        <profile id="f696-99de-a439-06cc" name="Bison (15cm) Gun [Artillery]" hidden="false" typeId="33b6-a72a-2bd8-2565" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="c2e5-4990-8105-f793">56&quot;/140cm</characteristic>
+            <characteristic name="Halted ROF" typeId="7f6e-6f8f-5f15-6e9d">ARTILLERY</characteristic>
+            <characteristic name="Moving ROF" typeId="f78e-b583-b3a5-754a"/>
+            <characteristic name="Anti-Tank" typeId="f57e-fa10-d0f9-e2dd">3</characteristic>
+            <characteristic name="Firepower" typeId="9cf3-a34f-60d9-1309">2+</characteristic>
+            <characteristic name="Notes" typeId="d939-5084-e654-44c6">Forward Firing</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="0d86-747c-e410-88c4" name="Bison (15cm) Gun [Direct Fire]" hidden="false" typeId="33b6-a72a-2bd8-2565" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="c2e5-4990-8105-f793">16&quot;/140cm</characteristic>
+            <characteristic name="Halted ROF" typeId="7f6e-6f8f-5f15-6e9d">1</characteristic>
+            <characteristic name="Moving ROF" typeId="f78e-b583-b3a5-754a">1</characteristic>
+            <characteristic name="Anti-Tank" typeId="f57e-fa10-d0f9-e2dd">7</characteristic>
+            <characteristic name="Firepower" typeId="9cf3-a34f-60d9-1309">AUTO</characteristic>
+            <characteristic name="Notes" typeId="d939-5084-e654-44c6">Brutal, Forward Firing, Slow Firing</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="f918-4f77-836b-e21d" name="Brutal" hidden="false" targetId="97da-9a33-4ff1-56f2" type="rule"/>
+        <infoLink id="c2d1-36e3-0147-e813" name="Slow Firing" hidden="false" targetId="e215-d5bf-83ce-606a" type="rule"/>
+        <infoLink id="9de9-a63d-38d7-6879" name="Forward Firing" hidden="false" targetId="fa9d-68f6-57d9-dc5d" type="rule"/>
+        <infoLink id="c616-55b9-902d-c6dc" name="Third Reich" hidden="false" targetId="0d32-e61c-3e35-7b9e" type="rule"/>
+      </infoLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="b08b-ce4d-c91e-4828" name="Unit Size" hidden="false" collective="false" import="true" defaultSelectionEntryId="91fc-38c1-344c-19c9">
+          <selectionEntries>
+            <selectionEntry id="91fc-38c1-344c-19c9" name="Bison Infantry Gun " hidden="false" collective="false" import="true" type="model">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a20c-b391-6d94-844f" type="min"/>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b1fd-9dee-31d1-c892" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="995a-4d67-6920-bfe4" value="3.5"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="dce3-dd07-476e-d810" name="Tiger (P)" hidden="false" collective="false" import="true" type="unit">
+      <profiles>
+        <profile id="d86e-d64c-7e36-a052" name="Tiger (P)" hidden="false" typeId="55ec-3ef5-ca51-e647" typeName="Tank Unit">
+          <characteristics>
+            <characteristic name="Motivation" typeId="046a-7f27-8072-dedb">4+ / 2+ Last Stand / 2+ Remount</characteristic>
+            <characteristic name="Skill" typeId="6334-745a-f712-a0aa">3+</characteristic>
+            <characteristic name="Is Hit On" typeId="3931-565d-e382-fda5">4+</characteristic>
+            <characteristic name="Armour Front" typeId="b88a-3ca6-9b40-ff73">9</characteristic>
+            <characteristic name="Armour Side &amp; Rear" typeId="3712-51b3-aae3-94bd">8</characteristic>
+            <characteristic name="Armour Top" typeId="f551-1392-03e8-967d">2</characteristic>
+            <characteristic name="Tactical" typeId="ea9a-bf7d-68c5-e2d7">8&quot;/20cm</characteristic>
+            <characteristic name="Terrain Dash" typeId="f7f4-9e66-c9ed-034b">12&quot;/30cm</characteristic>
+            <characteristic name="Cross Country Dash" typeId="f73b-6fcf-b0d1-fde4">14&quot;/35cm</characteristic>
+            <characteristic name="Road Dash" typeId="b5b1-c829-470a-af62">16&quot;/40cm</characteristic>
+            <characteristic name="Cross" typeId="8be2-d5b6-ec4a-76d9">2+</characteristic>
+            <characteristic name="Notes" typeId="33d6-6375-9564-9985"/>
+          </characteristics>
+        </profile>
+        <profile id="d701-b4ee-1905-5957" name="Tiger (P) (8.8cm)" hidden="false" typeId="33b6-a72a-2bd8-2565" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="c2e5-4990-8105-f793">40&quot;/100cm</characteristic>
+            <characteristic name="Halted ROF" typeId="7f6e-6f8f-5f15-6e9d">2</characteristic>
+            <characteristic name="Moving ROF" typeId="f78e-b583-b3a5-754a">1</characteristic>
+            <characteristic name="Anti-Tank" typeId="f57e-fa10-d0f9-e2dd">14</characteristic>
+            <characteristic name="Firepower" typeId="9cf3-a34f-60d9-1309">3+</characteristic>
+            <characteristic name="Notes" typeId="d939-5084-e654-44c6"/>
+          </characteristics>
+        </profile>
+        <profile id="55e3-a061-9752-ccd4" name="Tiger (P) (MGs)" hidden="false" typeId="33b6-a72a-2bd8-2565" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="c2e5-4990-8105-f793">16&quot;/40cm</characteristic>
+            <characteristic name="Halted ROF" typeId="7f6e-6f8f-5f15-6e9d">4</characteristic>
+            <characteristic name="Moving ROF" typeId="f78e-b583-b3a5-754a">4</characteristic>
+            <characteristic name="Anti-Tank" typeId="f57e-fa10-d0f9-e2dd">2</characteristic>
+            <characteristic name="Firepower" typeId="9cf3-a34f-60d9-1309">6</characteristic>
+            <characteristic name="Notes" typeId="d939-5084-e654-44c6"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="e80d-ad16-ac1b-3000" name="Stormtroopers" hidden="false" targetId="5b29-2623-7f34-fc95" type="rule"/>
+        <infoLink id="fa3c-9714-3fef-2052" name="Escort Tanks" hidden="false" targetId="3ee0-bd48-245e-56a8" type="rule"/>
+      </infoLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="4940-ddf4-c111-3f68" name="Unit Size" hidden="false" collective="false" import="true" defaultSelectionEntryId="a87f-5a39-1ffb-3470">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8b74-7438-82ca-93be" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="23b9-1262-5ade-d968" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="a87f-5a39-1ffb-3470" name="Tiger (P)" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ab33-32ca-c0cb-191d" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="995a-4d67-6920-bfe4" value="29.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="0236-d448-2f57-da9d" name="Escort Tanks" hidden="false" collective="false" import="true">
+          <modifiers>
+            <modifier type="set" field="9502-288e-83d5-95d9" value="2.0">
+              <conditions>
+                <condition field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a87f-5a39-1ffb-3470" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="9502-288e-83d5-95d9" value="1.0">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a87f-5a39-1ffb-3470" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9502-288e-83d5-95d9" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="62b5-7cfa-3c1a-cc40" name="Panzer III (7.5cm)" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7aa1-67ee-ab9b-52d0" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="ffda-ed35-82f6-368c" name="Panzer III (7.5cm)" hidden="false" targetId="e95a-01e2-de0f-70be" type="profile"/>
+                <infoLink id="397a-7be1-5f7c-d22a" name="HEAT" hidden="false" targetId="9a14-019a-eb63-0b40" type="rule"/>
+                <infoLink id="c8cc-8d21-7c3b-3a14" name="Panzer III" hidden="false" targetId="d19f-9a03-5a2f-b5a3" type="profile"/>
+                <infoLink id="8c28-c45d-123d-d061" name="Panzer III (MGs)" hidden="false" targetId="6b68-30d1-3bf7-9c64" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="995a-4d67-6920-bfe4" value="8.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="ac2b-d50e-773b-c8b7" name="Panzer III (Uparmoured)" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="627c-b8fd-9375-2924" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="d95c-5970-b757-8b25" name="Panzer III (uparmoured)" hidden="false" targetId="c1d6-72c3-6ff0-b7ad" type="profile"/>
+                <infoLink id="bab4-da19-b228-7baf" name="Panzer III (long 5cm)" hidden="false" targetId="c348-31c6-abda-445f" type="profile"/>
+                <infoLink id="8f91-4d2b-b26b-e3f5" name="Panzer III (MGs)" hidden="false" targetId="6b68-30d1-3bf7-9c64" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="995a-4d67-6920-bfe4" value="8.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="af10-4254-0bc5-5249" name="[INCOMPLETE] 7.62cm Tank-hunter Platoon" hidden="true" collective="false" import="true" type="unit">
+      <profiles>
+        <profile id="8532-d2ca-29c1-831b" name="7.62cm gun" hidden="false" typeId="33b6-a72a-2bd8-2565" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="c2e5-4990-8105-f793">32&quot;/80cm</characteristic>
+            <characteristic name="Halted ROF" typeId="7f6e-6f8f-5f15-6e9d">2</characteristic>
+            <characteristic name="Moving ROF" typeId="f78e-b583-b3a5-754a">1</characteristic>
+            <characteristic name="Anti-Tank" typeId="f57e-fa10-d0f9-e2dd">12</characteristic>
+            <characteristic name="Firepower" typeId="9cf3-a34f-60d9-1309">3+</characteristic>
+            <characteristic name="Notes" typeId="d939-5084-e654-44c6">Forward Firing</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="6d7a-323b-4cf4-ba95" name="ZZZ [S] 7.62cm Tank-hunter Platoon" hidden="false" typeId="7c70-b6af-9e5a-e7f6" typeName="Gun Unit">
+          <characteristics>
+            <characteristic name="Motivation" typeId="0954-f596-53ea-4ef7">4+ / 3+ Last Stand</characteristic>
+            <characteristic name="Skill" typeId="a907-592d-ab2d-5ead">3+ / 4+ Assault</characteristic>
+            <characteristic name="Is Hit On" typeId="1f89-085b-464b-c60f">4+</characteristic>
+            <characteristic name="Save" typeId="ae14-5890-03de-a715">4+</characteristic>
+            <characteristic name="Tactical" typeId="3bad-79bd-27aa-4539">-</characteristic>
+            <characteristic name="Terrain Dash" typeId="a400-d543-6fb9-26d0">2&quot;/5cm</characteristic>
+            <characteristic name="Cross Country Dash" typeId="34ca-877a-8ffa-1006">4&quot;/10cm</characteristic>
+            <characteristic name="Road Dash" typeId="d283-e066-839c-fbd7">6&quot;/15cm</characteristic>
+            <characteristic name="Cross" typeId="3f9c-89f9-0b29-0585">5+</characteristic>
+            <characteristic name="Notes" typeId="28aa-390d-006a-1776"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="ea89-0f28-cb6e-bae2" name="Forward Firing" hidden="false" targetId="fa9d-68f6-57d9-dc5d" type="rule"/>
+        <infoLink id="01ac-3e61-3a6a-4427" name="Large Gun" hidden="false" targetId="183b-aef0-86e1-693f" type="rule"/>
+        <infoLink id="c7a4-05ea-5a7d-0259" name="Gun Shield" hidden="false" targetId="2f2d-c5a9-ef7e-1b5e" type="rule"/>
+        <infoLink id="d3fb-e79a-12e4-6cc8" name="Gun" hidden="false" targetId="139e-9d64-28a3-a3dd" type="rule"/>
+        <infoLink id="82f9-def9-3cff-8fc1" name="Third Reich" hidden="false" targetId="0d32-e61c-3e35-7b9e" type="rule"/>
+      </infoLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="6f64-5dfd-ada4-d101" name="Unit Size" hidden="false" collective="false" import="true" defaultSelectionEntryId="e211-92a9-05f2-aca8">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="997d-a560-a4e6-ccc1" type="min"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a989-6be5-1818-e197" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="e211-92a9-05f2-aca8" name="7.62cm gun" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a80a-e685-a5b2-5b46" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="995a-4d67-6920-bfe4" value="3.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3d6b-4912-00bd-0da6" name="Marder, Marder II, or Diana Support Unit" hidden="false" collective="false" import="true" type="unit">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="a7ae-1357-a905-2488" name="Type" hidden="false" collective="false" import="true" defaultSelectionEntryId="eea0-da30-dc23-d189">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4182-0b70-c246-1b85" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ab56-03f1-de35-1885" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="c9f3-56b7-974a-ecbf" name="[INCOMPLETE] Diana Tank-hunter Platoon" hidden="false" collective="false" import="true" targetId="d3c7-0925-b18f-12f2" type="selectionEntry"/>
+            <entryLink id="eea0-da30-dc23-d189" name="Marder Tank-hunter Platoon" hidden="false" collective="false" import="true" targetId="51a5-c183-5f03-fbc5" type="selectionEntry"/>
+            <entryLink id="ec99-709d-123f-089d" name="Fallschirmjager Marder II Tank-hunter Platoon" hidden="false" collective="false" import="true" targetId="9e3e-0802-adea-3947" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="51a5-c183-5f03-fbc5" name="Marder Tank-hunter Platoon" hidden="false" collective="false" import="true" type="unit">
+      <infoLinks>
+        <infoLink id="d908-9c00-8e7d-2990" name="Marder (MG)" hidden="false" targetId="97b0-83cc-f31b-4736" type="profile"/>
+        <infoLink id="a384-72a7-fa5b-afed" name="Marder (7.62cm)" hidden="false" targetId="f210-c183-8e8c-ce85" type="profile"/>
+        <infoLink id="6ca4-9f19-86cc-d45c" name="Forward Firing" hidden="false" targetId="fa9d-68f6-57d9-dc5d" type="rule"/>
+        <infoLink id="5171-400a-2fe3-4ff7" name="Third Reich" hidden="false" targetId="0d32-e61c-3e35-7b9e" type="rule"/>
+        <infoLink id="26aa-25de-16dc-40d4" name="Stormtroopers" hidden="false" targetId="5b29-2623-7f34-fc95" type="rule"/>
+        <infoLink id="d1f7-c042-577e-3726" name="SP Gun" hidden="false" targetId="8f04-5766-b365-655a" type="rule"/>
+        <infoLink id="2db1-8bfd-7f0e-f027" name="Marder (7.62cm) [Unit]" hidden="false" targetId="2bf7-c313-c8d1-5c96" type="profile"/>
+      </infoLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="b674-75f5-8e68-8e92" name="Unit Size" publicationId="b8e5-51cf-456c-eafb" hidden="false" collective="false" import="true" defaultSelectionEntryId="e434-9122-5fb9-5a2f">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5ffc-dc7b-b536-e997" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d79e-797c-0abf-c0da" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="96c4-7250-b44c-fbb3" name="3x Marder (7.62cm)" hidden="false" collective="false" import="true" type="upgrade">
+              <costs>
+                <cost name="pts" typeId="995a-4d67-6920-bfe4" value="12.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="2308-e422-4f24-5c44" name="4x Marder (7.62cm)" hidden="false" collective="false" import="true" type="upgrade">
+              <costs>
+                <cost name="pts" typeId="995a-4d67-6920-bfe4" value="16.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="e434-9122-5fb9-5a2f" name="2x Marder (7.62cm)" hidden="false" collective="false" import="true" type="upgrade">
+              <costs>
+                <cost name="pts" typeId="995a-4d67-6920-bfe4" value="8.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="deae-76d6-e7a0-ee09" name="Observation Post Support Unit" hidden="false" collective="false" import="true" type="unit">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="8aee-b4ae-79a0-c1ad" name="Type" hidden="false" collective="false" import="true" defaultSelectionEntryId="3a84-f13a-8c7b-9a10">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7ef5-dcdc-30a0-16d2" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3c9f-5ebb-04d1-53d4" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="3a84-f13a-8c7b-9a10" name="Panzer II OP Observation Post " hidden="false" collective="false" import="true" targetId="4b88-0aac-85da-1695" type="selectionEntry"/>
+            <entryLink id="b0d1-3670-6f48-631c" name="Fallschirmjager Observation Post" hidden="false" collective="false" import="true" targetId="ab61-b1d3-2a76-30e8" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6071-147c-22e8-f008" name="Anti-Air Support Unit" hidden="false" collective="false" import="true" type="unit">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="2d3a-77d5-8961-2314" name="Type" hidden="false" collective="false" import="true" defaultSelectionEntryId="6f70-236a-5d66-4178">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0e4b-a6d5-8fd7-7a43" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9954-f00c-aeb7-2843" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="6f70-236a-5d66-4178" name="[AR] Sd Kfz 10/4 Light AA Platoon" hidden="false" collective="false" import="true" targetId="e176-eaf3-6806-dfb4" type="selectionEntry"/>
+            <entryLink id="183b-12d5-e0b0-fb12" name="2cm Anti-aircraft Platoon" hidden="false" collective="false" import="true" targetId="f2cc-e643-a855-c888" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3441-c8cd-e5d5-4d45" name="Artillery Support Unit" hidden="false" collective="false" import="true" type="unit">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="6999-2664-9a69-251a" name="Type" hidden="false" collective="false" import="true" defaultSelectionEntryId="008a-e5de-2a9c-d9f5">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="89a0-6387-233d-b8cc" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="653d-238b-e1fb-71c8" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="008a-e5de-2a9c-d9f5" name="10.5cm Artillery Battery" hidden="false" collective="false" import="true" targetId="8b75-1589-5690-3654" type="selectionEntry"/>
+            <entryLink id="17a3-00c3-9b15-b188" name="Fallschirmjager 10.5cm Recoilless Battery" hidden="false" collective="false" import="true" targetId="ee5b-b00a-238f-0dac" type="selectionEntry"/>
+            <entryLink id="fe56-39fb-09d3-6a63" name="[INCOMPLETE] 15cm Bison Infantry Gun Platoon" hidden="false" collective="false" import="true" targetId="b39f-8fd8-5ccd-6bf6" type="selectionEntry"/>
+            <entryLink id="e331-8f13-cc45-6def" name="Fallschirmjager 7.5cm Tank-Hunter Platoon" hidden="false" collective="false" import="true" targetId="ee8c-8e4d-3a7a-25ff" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="12d0-e7e5-e7b2-a4e1" name="Heavy AT Support Unit" hidden="false" collective="false" import="true" type="unit">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="da0b-e869-46de-1dde" name="Type" hidden="false" collective="false" import="true" defaultSelectionEntryId="aec2-005c-9aa8-f935">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e9a0-d474-94f6-3887" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9dad-3ae4-3b54-da5c" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="aec2-005c-9aa8-f935" name="[S] 8.8cm Heavy AA Platoon" hidden="false" collective="false" import="true" targetId="233e-1bc9-4a0c-d1fd" type="selectionEntry"/>
+            <entryLink id="0b81-ced6-b1c1-7851" name="ZZZ [S] Fallschirmjager 7.5cm Artillery Battery" hidden="false" collective="false" import="true" targetId="ee8c-8e4d-3a7a-25ff" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="982f-136d-902e-f70e" name="AT Support Unit" hidden="false" collective="false" import="true" type="unit">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="f9c1-e3c5-2395-34fd" name="Type" hidden="false" collective="false" import="true" defaultSelectionEntryId="2cba-de1c-4520-3475">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a4f2-fabd-328c-5ded" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a10b-a0a0-e937-2499" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="2cba-de1c-4520-3475" name="5cm Tank-Hunter Platoon" hidden="false" collective="false" import="true" targetId="1b66-d365-c756-7a90" type="selectionEntry"/>
+            <entryLink id="f21e-3e1b-8027-f7b7" name="Fallschirmjager 5cm Tank-Hunter Platoon" hidden="false" collective="false" import="true" targetId="1efc-46db-899d-7d86" type="selectionEntry"/>
+            <entryLink id="323f-0834-cd24-cf42" name="Fallschirmjager 3.7cm Tank-hunter Platoon" hidden="false" collective="false" import="true" targetId="6307-1844-7dc9-2701" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="d2d5-99f1-4c07-97d1" name="15cm (Sf) Lorraine Schlepper Artillery Battery" hidden="false" collective="false" import="true" type="unit">
+      <infoLinks>
+        <infoLink id="3fbe-9e65-345a-12f9" name="15cm (Sf) Lorraine Schlepper" hidden="false" targetId="26b6-6573-5075-a1fb" type="profile"/>
+        <infoLink id="bf33-029b-5d78-341e" name="15cm (Sf) howitzer Artillery" hidden="false" targetId="bf6e-857c-43d5-4c58" type="profile"/>
+        <infoLink id="6207-2755-d6be-8e70" name="Forward Firing" hidden="false" targetId="fa9d-68f6-57d9-dc5d" type="rule"/>
+        <infoLink id="53bf-a6b2-64b4-21b1" name="Stormtroopers" hidden="false" targetId="5b29-2623-7f34-fc95" type="rule"/>
+        <infoLink id="c084-6871-b37f-e7d6" name="SP Gun" hidden="false" targetId="8f04-5766-b365-655a" type="rule"/>
+        <infoLink id="fea8-a1c1-3a76-c1d9" name="15cm (Sf) howitzer [Direct Fire]" hidden="false" targetId="005f-4755-c31f-3075" type="profile"/>
+        <infoLink id="33c1-87ec-07ab-b901" name="Brutal" hidden="false" targetId="97da-9a33-4ff1-56f2" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="6bcf-8534-e614-ce4e" name="New CategoryLink" hidden="false" targetId="9be3-4dab-91f0-f7c5" primary="true"/>
+      </categoryLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="e2ed-48a3-aea3-832b" name="Unit Size" publicationId="b8e5-51cf-456c-eafb" hidden="false" collective="false" import="true" defaultSelectionEntryId="f894-d954-1815-5f25">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8148-645f-bfc8-4ed4" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fac2-6ecb-ae14-21ec" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="f894-d954-1815-5f25" name="2x 15cm (Sf) Lorraine Schlepper" hidden="false" collective="false" import="true" type="upgrade">
+              <costs>
+                <cost name="pts" typeId="995a-4d67-6920-bfe4" value="6.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="516f-48be-e54b-a33e" name="4x 15cm (Sf) Lorraine Schlepper" hidden="false" collective="false" import="true" type="upgrade">
+              <costs>
+                <cost name="pts" typeId="995a-4d67-6920-bfe4" value="12.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
+      </costs>
+    </selectionEntry>
+  </sharedSelectionEntries>
+  <sharedSelectionEntryGroups>
+    <selectionEntryGroup id="2d10-2052-ae3d-c5cf" name="Panzer III/IV Command Cards" hidden="false" collective="false" import="true">
+      <comment>Still need to write out all of these; I do not look forward to it. - Ursy</comment>
+      <selectionEntries>
+        <selectionEntry id="65c9-709f-bf42-9c4a" name="Josef Rettemeier" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7d5d-2d85-efab-d339" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="995a-4d67-6920-bfe4" value="4.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="f62b-2afd-22a5-a8f8" name="Roll Over Them" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="70b0-dc43-6908-52b0" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="995a-4d67-6920-bfe4" value="4.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="5861-d206-1ca5-60c7" name="Precise Gunner" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0275-ed00-d5d3-8fec" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="995a-4d67-6920-bfe4" value="2.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="761d-f35d-9f4e-dd2c" name="Pinpoint Accuracy" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="553b-50ba-1dd2-5910" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="995a-4d67-6920-bfe4" value="1.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="5f54-4549-661d-4256" name="Mission Tactics" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="105e-ac4e-6839-2d98" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="995a-4d67-6920-bfe4" value="3.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="0f06-6410-1e8c-d559" name="Marksman" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bbd0-0cf4-55d2-47ae" type="max"/>
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6bc1-bfe6-eb09-522e" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="995a-4d67-6920-bfe4" value="1.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="3880-942d-2e2c-24d1" name="Hidden in Plain Sight" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="457a-fa26-49f1-e385" type="max"/>
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="daa0-87ad-17a7-fd79" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="995a-4d67-6920-bfe4" value="4.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="ad3d-be3c-ebb0-462f" name="Forward Scouts" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="42c4-afaa-d368-7a7a" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="995a-4d67-6920-bfe4" value="2.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="7ed6-9387-a056-b3c8" name="Blitzkrieg" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d557-770b-10bd-d290" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="995a-4d67-6920-bfe4" value="2.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="2eea-3268-4035-e733" name="Ferocious Valor" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="30f5-42bd-7069-e05b" type="max"/>
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="95ef-bc9b-53d0-56bc" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="995a-4d67-6920-bfe4" value="3.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="ab98-d7d9-a745-3de5" name="Every Shot Counts" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ca66-0b57-76f6-da1a" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="995a-4d67-6920-bfe4" value="3.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="4d16-0a69-619b-571d" name="Elite Crew" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6bb8-c496-5950-5d2a" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="995a-4d67-6920-bfe4" value="4.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="1eaf-374b-bce4-7b3c" name="Cut Them Down" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e6fc-d305-b762-ae07" type="max"/>
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9921-ff64-1305-eec7" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="995a-4d67-6920-bfe4" value="1.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="a114-e832-d2d1-fc67" name="Clever Tactics" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf80-747f-430e-a69d" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="995a-4d67-6920-bfe4" value="3.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="7b79-8e75-a703-acae" name="Charmed Life" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9eb9-19b3-3c35-cba2" type="max"/>
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6c50-a0b9-930f-c5fc" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="995a-4d67-6920-bfe4" value="2.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="6898-64df-3c37-3499" name="Afrika Rifle Command Cards" hidden="false" collective="false" import="true">
+      <comment>Still need to write out all of these; I do not look forward to it. - Ursy</comment>
+      <selectionEntries>
+        <selectionEntry id="c415-75c6-c098-76fa" name="Panzer-Knacker" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4a24-c1a9-9498-643a" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="995a-4d67-6920-bfe4" value="2.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="1bd8-0d0a-51d5-002f" name="Trench Fighter" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="acb0-63af-432e-8dbf" type="max"/>
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e8c7-eb15-ddd3-0844" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="995a-4d67-6920-bfe4" value="2.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="3290-627f-8ecd-f544" name="Softskin Transport" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a436-3db0-d062-5398" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="a5cc-f35e-65cf-ce06" name="Softskin Transport" hidden="false" typeId="7cf5-5c36-14cc-3c0d" typeName="Unarmoured Tank Unit">
+              <characteristics>
+                <characteristic name="Motivation" typeId="55ef-8653-887d-4642">4+</characteristic>
+                <characteristic name="Skill" typeId="229c-c44f-2910-c1d1">3+</characteristic>
+                <characteristic name="Is Hit On" typeId="acbb-3bc2-c667-6e4d">4+</characteristic>
+                <characteristic name="Save" typeId="6e6b-7d9e-7557-43cd">5+</characteristic>
+                <characteristic name="Tactical" typeId="6caa-857a-dce7-e965">-</characteristic>
+                <characteristic name="Terrain Dash" typeId="f188-5e37-f014-5069">10&quot;/25cm</characteristic>
+                <characteristic name="Cross Country Dash" typeId="d2da-b73b-7a4a-ca53">18&quot;/45cm</characteristic>
+                <characteristic name="Road Dash" typeId="271f-e64c-128c-5740">40&quot;/100cm</characteristic>
+                <characteristic name="Cross" typeId="b443-5f9e-d0b5-48b0">4+</characteristic>
+                <characteristic name="Notes" typeId="5c4c-b4d7-c2d1-6a93"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="c18a-fbf1-3545-4801" name="Passengers 2" hidden="false">
+              <description>Team can carry two Infantry Teams as Passangers</description>
+            </rule>
+            <rule id="3bbd-991b-24ba-6a2b" name="Softskin" hidden="false">
+              <description>If a Transport is Destroyed, any Passangers it is carrying are also Destroyed, and all Tranports must be Sent to the Rear immediately. All Passangers must Dismount from this Unit at the same time. Empty Tranpost Teams must be Sent to the Rear</description>
+            </rule>
+            <rule id="182b-622b-fad5-e9b7" name="Tractor" hidden="false">
+              <description>Team can carry one Gun Team as Passangers.	</description>
+            </rule>
+            <rule id="e935-2937-237e-ff93" name="Unarmoured" hidden="false">
+              <description>Tram cannot Charge into Contact and must Break Off if Assaulted</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="pts" typeId="995a-4d67-6920-bfe4" value="1.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="5a57-0c1b-ae66-c30d" name="Pioneer Company" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2d6c-4fda-dc6a-d595" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="995a-4d67-6920-bfe4" value="1.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="43b6-63d1-15f6-e226" name="Mission Tactics" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5721-47ac-6376-17ad" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="995a-4d67-6920-bfe4" value="3.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="e5fd-0db4-55c6-2e04" name="Marksman" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0593-f911-87e5-b086" type="max"/>
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ecd8-ee85-ad11-13a9" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="995a-4d67-6920-bfe4" value="1.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="1fbc-f85e-a8a4-388f" name="Hidden in Plain Sight" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b758-fb5d-ba93-27a2" type="max"/>
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e4ba-07e2-225f-4fcc" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="995a-4d67-6920-bfe4" value="4.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="b5ec-cdd3-e3b6-9c90" name="Blitzkrieg" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2524-1f21-5ce7-ec3d" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="995a-4d67-6920-bfe4" value="2.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="7e0f-7e78-4dd9-e556" name="Fortify the Building" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e29c-e01a-a4d4-f126" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="995a-4d67-6920-bfe4" value="2.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="4100-7338-1378-7821" name="Ferocious Valor" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ded8-76d3-09d8-20d8" type="max"/>
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b3f6-eb18-e3e0-ef1e" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="995a-4d67-6920-bfe4" value="3.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="bba1-5356-50c0-977f" name="Dead Eye" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="49b3-881e-3d44-bf16" type="max"/>
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2467-85c3-0d9e-702b" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="995a-4d67-6920-bfe4" value="2.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="5413-685c-8977-bfcf" name="Cut Them Down" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="906e-3745-cd59-e5f6" type="max"/>
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="073f-602b-96dd-c0ad" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="995a-4d67-6920-bfe4" value="1.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="1d60-6f15-e892-2ac1" name="Captured Tank" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e84b-16c3-f98a-ef1d" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="995a-4d67-6920-bfe4" value="1.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="0023-fb29-a326-8a1d" name="Captured 6 pdr" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b83c-fedb-1c55-ca2a" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="3b09-3af3-d34f-6789" name="Artillery Command Cards" hidden="false" collective="false" import="true">
+      <comment>Still need to write out all of these; I do not look forward to it. - Ursy</comment>
+      <selectionEntries>
+        <selectionEntry id="fc01-81fb-76cd-cb91" name="Softskin Transport" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dedc-4b8c-63dc-0ba3" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="80e9-3d83-04bb-7f4f" name="Softskin Transport" hidden="false" typeId="7cf5-5c36-14cc-3c0d" typeName="Unarmoured Tank Unit">
+              <characteristics>
+                <characteristic name="Motivation" typeId="55ef-8653-887d-4642">4+</characteristic>
+                <characteristic name="Skill" typeId="229c-c44f-2910-c1d1">3+</characteristic>
+                <characteristic name="Is Hit On" typeId="acbb-3bc2-c667-6e4d">4+</characteristic>
+                <characteristic name="Save" typeId="6e6b-7d9e-7557-43cd">5+</characteristic>
+                <characteristic name="Tactical" typeId="6caa-857a-dce7-e965">-</characteristic>
+                <characteristic name="Terrain Dash" typeId="f188-5e37-f014-5069">10&quot;/25cm</characteristic>
+                <characteristic name="Cross Country Dash" typeId="d2da-b73b-7a4a-ca53">18&quot;/45cm</characteristic>
+                <characteristic name="Road Dash" typeId="271f-e64c-128c-5740">40&quot;/100cm</characteristic>
+                <characteristic name="Cross" typeId="b443-5f9e-d0b5-48b0">4+</characteristic>
+                <characteristic name="Notes" typeId="5c4c-b4d7-c2d1-6a93"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="ed4b-a2b1-57e3-a985" name="Passengers 2" hidden="false">
+              <description>Team can carry two Infantry Teams as Passangers</description>
+            </rule>
+            <rule id="d21b-49f2-e24c-8244" name="Softskin" hidden="false">
+              <description>If a Transport is Destroyed, any Passangers it is carrying are also Destroyed, and all Tranports must be Sent to the Rear immediately. All Passangers must Dismount from this Unit at the same time. Empty Tranpost Teams must be Sent to the Rear</description>
+            </rule>
+            <rule id="32a9-db06-341c-d4c9" name="Tractor" hidden="false">
+              <description>Team can carry one Gun Team as Passangers.	</description>
+            </rule>
+            <rule id="7c24-a3d2-8a31-bb02" name="Unarmoured" hidden="false">
+              <description>Tram cannot Charge into Contact and must Break Off if Assaulted</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="pts" typeId="995a-4d67-6920-bfe4" value="1.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="53f4-0ff2-8516-dc55" name="Captured 6 pdr" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="69b7-94b2-dc1f-8e49" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="35d3-c972-bc93-8d54" name="Captured 25 pdr" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eea8-9c9a-9797-bc02" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+  </sharedSelectionEntryGroups>
+  <sharedRules>
+    <rule id="9a14-019a-eb63-0b40" name="HEAT" hidden="false">
+      <description>A Team&apos;s Armour rating is not increased by +1 if it is more than 16&quot;/40cm away when hit by HEAT weapons.</description>
+    </rule>
+    <rule id="5b29-2623-7f34-fc95" name="Stormtroopers" hidden="false">
+      <description>A unit may attempt a second Movement Order after succeeding in its first Movement Order. The second Movement Order must be different from the first.</description>
+    </rule>
+    <rule id="0d32-e61c-3e35-7b9e" name="Third Reich" hidden="false">
+      <description>Troops of the Third Reich have a better Last Stand rating.</description>
+    </rule>
+    <rule id="d58a-ba48-0bc7-b673" name="Tiger Ace" hidden="false">
+      <description>Tiger Aces have a better Last Stand rating and a significantly better Remount rating.</description>
+    </rule>
+    <rule id="3ee0-bd48-245e-56a8" name="Escort Tanks" hidden="false">
+      <description>You may add one Escort Tank, either a Panzer III (Uparmoured) or a Panzer III (7.5cm), for each Tiger tank in a Heavy Panzer Platoon for the points shown in the unit organisation. Use the characteristics shown on the Panzer  III Tank Platoon and Panzer III (uparmoured) Tank Platoon for these tanks.
+
+Ignore Bailed Out or Destroyed Escort tanks when determining if the Unit is In Good Spirits, so if there are no Bailed Out or Destroyed Tiger tanks, the unit will be In Good Spritits.
+
+A Tiger Heavy Tanks Platoon has a Last Stand rating of 2+, whether or not it has Escort tanks. </description>
+    </rule>
+  </sharedRules>
+  <sharedProfiles>
+    <profile id="d19f-9a03-5a2f-b5a3" name="Panzer III" hidden="false" typeId="55ec-3ef5-ca51-e647" typeName="Tank Unit">
+      <characteristics>
+        <characteristic name="Motivation" typeId="046a-7f27-8072-dedb">4+ / 3+ Last Stand / 3+ Remount</characteristic>
+        <characteristic name="Skill" typeId="6334-745a-f712-a0aa">3+</characteristic>
+        <characteristic name="Is Hit On" typeId="3931-565d-e382-fda5">4+</characteristic>
+        <characteristic name="Armour Front" typeId="b88a-3ca6-9b40-ff73">5</characteristic>
+        <characteristic name="Armour Side &amp; Rear" typeId="3712-51b3-aae3-94bd">3</characteristic>
+        <characteristic name="Armour Top" typeId="f551-1392-03e8-967d">1</characteristic>
+        <characteristic name="Tactical" typeId="ea9a-bf7d-68c5-e2d7">10&quot;/25cm</characteristic>
+        <characteristic name="Terrain Dash" typeId="f7f4-9e66-c9ed-034b">12&quot;/30cm</characteristic>
+        <characteristic name="Cross Country Dash" typeId="f73b-6fcf-b0d1-fde4">18&quot;/45cm</characteristic>
+        <characteristic name="Road Dash" typeId="b5b1-c829-470a-af62">20&quot;/50cm</characteristic>
+        <characteristic name="Cross" typeId="8be2-d5b6-ec4a-76d9">3+</characteristic>
+        <characteristic name="Notes" typeId="33d6-6375-9564-9985"/>
+      </characteristics>
+    </profile>
+    <profile id="c1d6-72c3-6ff0-b7ad" name="Panzer III (uparmoured)" hidden="false" typeId="55ec-3ef5-ca51-e647" typeName="Tank Unit">
+      <characteristics>
+        <characteristic name="Motivation" typeId="046a-7f27-8072-dedb">4+ / 3+ Last Stand / 3+ Remount</characteristic>
+        <characteristic name="Skill" typeId="6334-745a-f712-a0aa">3+</characteristic>
+        <characteristic name="Is Hit On" typeId="3931-565d-e382-fda5">4+</characteristic>
+        <characteristic name="Armour Front" typeId="b88a-3ca6-9b40-ff73">6</characteristic>
+        <characteristic name="Armour Side &amp; Rear" typeId="3712-51b3-aae3-94bd">3</characteristic>
+        <characteristic name="Armour Top" typeId="f551-1392-03e8-967d">1</characteristic>
+        <characteristic name="Tactical" typeId="ea9a-bf7d-68c5-e2d7">10&quot;/25cm</characteristic>
+        <characteristic name="Terrain Dash" typeId="f7f4-9e66-c9ed-034b">12&quot;/30cm</characteristic>
+        <characteristic name="Cross Country Dash" typeId="f73b-6fcf-b0d1-fde4">18&quot;/45cm</characteristic>
+        <characteristic name="Road Dash" typeId="b5b1-c829-470a-af62">20&quot;/50cm</characteristic>
+        <characteristic name="Cross" typeId="8be2-d5b6-ec4a-76d9">3+</characteristic>
+        <characteristic name="Notes" typeId="33d6-6375-9564-9985"/>
+      </characteristics>
+    </profile>
+    <profile id="27d6-4340-e9e0-489a" name="Panzer III (short 5cm)" hidden="false" typeId="33b6-a72a-2bd8-2565" typeName="Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="c2e5-4990-8105-f793">24&quot;/60cm</characteristic>
+        <characteristic name="Halted ROF" typeId="7f6e-6f8f-5f15-6e9d">2</characteristic>
+        <characteristic name="Moving ROF" typeId="f78e-b583-b3a5-754a">1</characteristic>
+        <characteristic name="Anti-Tank" typeId="f57e-fa10-d0f9-e2dd">8</characteristic>
+        <characteristic name="Firepower" typeId="9cf3-a34f-60d9-1309">4+</characteristic>
+        <characteristic name="Notes" typeId="d939-5084-e654-44c6"/>
+      </characteristics>
+    </profile>
+    <profile id="e95a-01e2-de0f-70be" name="Panzer III (7.5cm)" hidden="false" typeId="33b6-a72a-2bd8-2565" typeName="Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="c2e5-4990-8105-f793">24&quot;/60cm</characteristic>
+        <characteristic name="Halted ROF" typeId="7f6e-6f8f-5f15-6e9d">2</characteristic>
+        <characteristic name="Moving ROF" typeId="f78e-b583-b3a5-754a">1</characteristic>
+        <characteristic name="Anti-Tank" typeId="f57e-fa10-d0f9-e2dd">9</characteristic>
+        <characteristic name="Firepower" typeId="9cf3-a34f-60d9-1309">3+</characteristic>
+        <characteristic name="Notes" typeId="d939-5084-e654-44c6">HEAT</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="c348-31c6-abda-445f" name="Panzer III (long 5cm)" hidden="false" typeId="33b6-a72a-2bd8-2565" typeName="Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="c2e5-4990-8105-f793">28&quot;/70cm</characteristic>
+        <characteristic name="Halted ROF" typeId="7f6e-6f8f-5f15-6e9d">2</characteristic>
+        <characteristic name="Moving ROF" typeId="f78e-b583-b3a5-754a">1</characteristic>
+        <characteristic name="Anti-Tank" typeId="f57e-fa10-d0f9-e2dd">9</characteristic>
+        <characteristic name="Firepower" typeId="9cf3-a34f-60d9-1309">4+</characteristic>
+        <characteristic name="Notes" typeId="d939-5084-e654-44c6"/>
+      </characteristics>
+    </profile>
+    <profile id="6b68-30d1-3bf7-9c64" name="Panzer III (MGs)" hidden="false" typeId="33b6-a72a-2bd8-2565" typeName="Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="c2e5-4990-8105-f793">16&quot;/40cm</characteristic>
+        <characteristic name="Halted ROF" typeId="7f6e-6f8f-5f15-6e9d">4</characteristic>
+        <characteristic name="Moving ROF" typeId="f78e-b583-b3a5-754a">4</characteristic>
+        <characteristic name="Anti-Tank" typeId="f57e-fa10-d0f9-e2dd">2</characteristic>
+        <characteristic name="Firepower" typeId="9cf3-a34f-60d9-1309">6</characteristic>
+        <characteristic name="Notes" typeId="d939-5084-e654-44c6"/>
+      </characteristics>
+    </profile>
+    <profile id="f17d-c1b0-c078-5874" name="Panzer II (2cm) [Unit]" hidden="false" typeId="55ec-3ef5-ca51-e647" typeName="Tank Unit">
+      <modifiers>
+        <modifier type="set" field="name" value="Panzer II (2cm)"/>
+      </modifiers>
+      <characteristics>
+        <characteristic name="Motivation" typeId="046a-7f27-8072-dedb">4+ Last Stand 3+</characteristic>
+        <characteristic name="Skill" typeId="6334-745a-f712-a0aa">3+</characteristic>
+        <characteristic name="Is Hit On" typeId="3931-565d-e382-fda5">4+</characteristic>
+        <characteristic name="Armour Front" typeId="b88a-3ca6-9b40-ff73">3</characteristic>
+        <characteristic name="Armour Side &amp; Rear" typeId="3712-51b3-aae3-94bd">1</characteristic>
+        <characteristic name="Armour Top" typeId="f551-1392-03e8-967d">1</characteristic>
+        <characteristic name="Tactical" typeId="ea9a-bf7d-68c5-e2d7">10&quot;/25cm</characteristic>
+        <characteristic name="Terrain Dash" typeId="f7f4-9e66-c9ed-034b">12&quot;/30cm</characteristic>
+        <characteristic name="Cross Country Dash" typeId="f73b-6fcf-b0d1-fde4">18&quot;/45cm</characteristic>
+        <characteristic name="Road Dash" typeId="b5b1-c829-470a-af62">20&quot;/50cm</characteristic>
+        <characteristic name="Cross" typeId="8be2-d5b6-ec4a-76d9">3+</characteristic>
+        <characteristic name="Notes" typeId="33d6-6375-9564-9985"/>
+      </characteristics>
+    </profile>
+    <profile id="85a8-b4f2-1c62-0ec0" name="Panzer II (MG)" hidden="false" typeId="33b6-a72a-2bd8-2565" typeName="Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="c2e5-4990-8105-f793">16&quot;/40cm</characteristic>
+        <characteristic name="Halted ROF" typeId="7f6e-6f8f-5f15-6e9d">3</characteristic>
+        <characteristic name="Moving ROF" typeId="f78e-b583-b3a5-754a">3</characteristic>
+        <characteristic name="Anti-Tank" typeId="f57e-fa10-d0f9-e2dd">2</characteristic>
+        <characteristic name="Firepower" typeId="9cf3-a34f-60d9-1309">6</characteristic>
+        <characteristic name="Notes" typeId="d939-5084-e654-44c6"/>
+      </characteristics>
+    </profile>
+    <profile id="32ee-c8af-2401-7fcd" name="Panzer IV (short 7.5cm)" hidden="false" typeId="55ec-3ef5-ca51-e647" typeName="Tank Unit">
+      <characteristics>
+        <characteristic name="Motivation" typeId="046a-7f27-8072-dedb">4+ Last Stand 3+ Remount 3+</characteristic>
+        <characteristic name="Skill" typeId="6334-745a-f712-a0aa">3+</characteristic>
+        <characteristic name="Is Hit On" typeId="3931-565d-e382-fda5">4+</characteristic>
+        <characteristic name="Armour Front" typeId="b88a-3ca6-9b40-ff73">5</characteristic>
+        <characteristic name="Armour Side &amp; Rear" typeId="3712-51b3-aae3-94bd">3</characteristic>
+        <characteristic name="Armour Top" typeId="f551-1392-03e8-967d">1</characteristic>
+        <characteristic name="Tactical" typeId="ea9a-bf7d-68c5-e2d7">10&quot;/25cm</characteristic>
+        <characteristic name="Terrain Dash" typeId="f7f4-9e66-c9ed-034b">14&quot;/35cm</characteristic>
+        <characteristic name="Cross Country Dash" typeId="f73b-6fcf-b0d1-fde4">18&quot;/45cm</characteristic>
+        <characteristic name="Road Dash" typeId="b5b1-c829-470a-af62">20&quot;/50cm</characteristic>
+        <characteristic name="Cross" typeId="8be2-d5b6-ec4a-76d9">3+</characteristic>
+        <characteristic name="Notes" typeId="33d6-6375-9564-9985"/>
+      </characteristics>
+    </profile>
+    <profile id="e399-f101-ec82-1ecd" name="Panzer IV (short 7.5cm) [Direct Fire]" hidden="false" typeId="33b6-a72a-2bd8-2565" typeName="Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="c2e5-4990-8105-f793">24&quot;/60cm</characteristic>
+        <characteristic name="Halted ROF" typeId="7f6e-6f8f-5f15-6e9d">2</characteristic>
+        <characteristic name="Moving ROF" typeId="f78e-b583-b3a5-754a">1</characteristic>
+        <characteristic name="Anti-Tank" typeId="f57e-fa10-d0f9-e2dd">7</characteristic>
+        <characteristic name="Firepower" typeId="9cf3-a34f-60d9-1309">3+</characteristic>
+        <characteristic name="Notes" typeId="d939-5084-e654-44c6">Smoke</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="f01e-fa98-5ff0-a393" name="Panzer IV (short 7.5cm) [Artillery]" hidden="false" typeId="33b6-a72a-2bd8-2565" typeName="Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="c2e5-4990-8105-f793">48&quot;/120cm</characteristic>
+        <characteristic name="Halted ROF" typeId="7f6e-6f8f-5f15-6e9d">ARTILLERY</characteristic>
+        <characteristic name="Moving ROF" typeId="f78e-b583-b3a5-754a"/>
+        <characteristic name="Anti-Tank" typeId="f57e-fa10-d0f9-e2dd">2</characteristic>
+        <characteristic name="Firepower" typeId="9cf3-a34f-60d9-1309">4+</characteristic>
+        <characteristic name="Notes" typeId="d939-5084-e654-44c6"/>
+      </characteristics>
+    </profile>
+    <profile id="9c83-361f-4aff-74e9" name="Panzer IV (long 7.5cm)" hidden="false" typeId="33b6-a72a-2bd8-2565" typeName="Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="c2e5-4990-8105-f793">32&quot;/80cm</characteristic>
+        <characteristic name="Halted ROF" typeId="7f6e-6f8f-5f15-6e9d">2</characteristic>
+        <characteristic name="Moving ROF" typeId="f78e-b583-b3a5-754a">1</characteristic>
+        <characteristic name="Anti-Tank" typeId="f57e-fa10-d0f9-e2dd">10</characteristic>
+        <characteristic name="Firepower" typeId="9cf3-a34f-60d9-1309">3+</characteristic>
+        <characteristic name="Notes" typeId="d939-5084-e654-44c6"/>
+      </characteristics>
+    </profile>
+    <profile id="2123-1e99-f832-e359" name="Panzer IV (MGs)" hidden="false" typeId="33b6-a72a-2bd8-2565" typeName="Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="c2e5-4990-8105-f793">16&quot;/40cm</characteristic>
+        <characteristic name="Halted ROF" typeId="7f6e-6f8f-5f15-6e9d">4</characteristic>
+        <characteristic name="Moving ROF" typeId="f78e-b583-b3a5-754a">4</characteristic>
+        <characteristic name="Anti-Tank" typeId="f57e-fa10-d0f9-e2dd">2</characteristic>
+        <characteristic name="Firepower" typeId="9cf3-a34f-60d9-1309">6</characteristic>
+        <characteristic name="Notes" typeId="d939-5084-e654-44c6"/>
+      </characteristics>
+    </profile>
+    <profile id="198a-2c9e-9db8-5d2a" name="MP40 SMG team (Unit)" hidden="false" typeId="0917-e2f0-0c3e-b482" typeName="Infantry Unit">
+      <modifiers>
+        <modifier type="set" field="name" value="MP40 SMG team"/>
+      </modifiers>
+      <characteristics>
+        <characteristic name="Motivation" typeId="4aa0-1b18-70af-9474">4+ Last Stand 3+</characteristic>
+        <characteristic name="Skill" typeId="7258-881d-dc2d-e80b">3+</characteristic>
+        <characteristic name="Is Hit On" typeId="0641-f39f-6a33-7dcc">4+</characteristic>
+        <characteristic name="Save" typeId="4750-979d-b2bb-c536">3+</characteristic>
+        <characteristic name="Tactical" typeId="8027-bcf9-d953-3740">8&quot;/20cm</characteristic>
+        <characteristic name="Terrain Dash" typeId="b93a-5d61-9a77-50cc">8&quot;/20cm</characteristic>
+        <characteristic name="Cross Country Dash" typeId="4862-29d4-9ab9-76a0">12&quot;/30cm</characteristic>
+        <characteristic name="Road Dash" typeId="75e3-9f15-03c8-7f95">12&quot;/30cm</characteristic>
+        <characteristic name="Cross" typeId="2d03-7d6c-d869-db3f">AUTO</characteristic>
+        <characteristic name="Notes" typeId="173e-6395-d37b-31a2"/>
+      </characteristics>
+    </profile>
+    <profile id="a028-247a-e0b3-b53a" name="MP40 SMG team (Weapon)" hidden="false" typeId="33b6-a72a-2bd8-2565" typeName="Weapon">
+      <modifiers>
+        <modifier type="set" field="name" value="MP40 SMG team"/>
+      </modifiers>
+      <characteristics>
+        <characteristic name="Range" typeId="c2e5-4990-8105-f793">4&quot;/10cm</characteristic>
+        <characteristic name="Halted ROF" typeId="7f6e-6f8f-5f15-6e9d">3</characteristic>
+        <characteristic name="Moving ROF" typeId="f78e-b583-b3a5-754a">3</characteristic>
+        <characteristic name="Anti-Tank" typeId="f57e-fa10-d0f9-e2dd">1</characteristic>
+        <characteristic name="Firepower" typeId="9cf3-a34f-60d9-1309">6</characteristic>
+        <characteristic name="Notes" typeId="d939-5084-e654-44c6">Pinned ROF 1</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="dc51-5020-0fc4-c611" name="MG34 team (Weapon)" hidden="false" typeId="33b6-a72a-2bd8-2565" typeName="Weapon">
+      <modifiers>
+        <modifier type="set" field="name" value="MG34 team"/>
+      </modifiers>
+      <characteristics>
+        <characteristic name="Range" typeId="c2e5-4990-8105-f793">16&quot;/40cm</characteristic>
+        <characteristic name="Halted ROF" typeId="7f6e-6f8f-5f15-6e9d">3</characteristic>
+        <characteristic name="Moving ROF" typeId="f78e-b583-b3a5-754a">2</characteristic>
+        <characteristic name="Anti-Tank" typeId="f57e-fa10-d0f9-e2dd">2</characteristic>
+        <characteristic name="Firepower" typeId="9cf3-a34f-60d9-1309">6</characteristic>
+        <characteristic name="Notes" typeId="d939-5084-e654-44c6"/>
+      </characteristics>
+    </profile>
+    <profile id="5589-f659-399a-20b8" name="2.8cm anti-tank rifle" hidden="false" typeId="33b6-a72a-2bd8-2565" typeName="Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="c2e5-4990-8105-f793">20&quot;/50cm</characteristic>
+        <characteristic name="Halted ROF" typeId="7f6e-6f8f-5f15-6e9d">2</characteristic>
+        <characteristic name="Moving ROF" typeId="f78e-b583-b3a5-754a">1</characteristic>
+        <characteristic name="Anti-Tank" typeId="f57e-fa10-d0f9-e2dd">7</characteristic>
+        <characteristic name="Firepower" typeId="9cf3-a34f-60d9-1309">5+</characteristic>
+        <characteristic name="Notes" typeId="d939-5084-e654-44c6">Assault 4+, Heavy Weapon, No HE</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="bae9-90b2-6eb3-95c6" name="sMG34 HMG" hidden="false" typeId="33b6-a72a-2bd8-2565" typeName="Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="c2e5-4990-8105-f793">24&quot;/60cm</characteristic>
+        <characteristic name="Halted ROF" typeId="7f6e-6f8f-5f15-6e9d">6</characteristic>
+        <characteristic name="Moving ROF" typeId="f78e-b583-b3a5-754a">2</characteristic>
+        <characteristic name="Anti-Tank" typeId="f57e-fa10-d0f9-e2dd">2</characteristic>
+        <characteristic name="Firepower" typeId="9cf3-a34f-60d9-1309">6</characteristic>
+        <characteristic name="Notes" typeId="d939-5084-e654-44c6">Assault 4+, Heavy Weapon</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="5328-88c0-a5ee-781a" name="8cm mortar" hidden="false" typeId="33b6-a72a-2bd8-2565" typeName="Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="c2e5-4990-8105-f793">40&quot;/100cm</characteristic>
+        <characteristic name="Halted ROF" typeId="7f6e-6f8f-5f15-6e9d">ARTILLERY</characteristic>
+        <characteristic name="Moving ROF" typeId="f78e-b583-b3a5-754a"/>
+        <characteristic name="Anti-Tank" typeId="f57e-fa10-d0f9-e2dd">1</characteristic>
+        <characteristic name="Firepower" typeId="9cf3-a34f-60d9-1309">4+</characteristic>
+        <characteristic name="Notes" typeId="d939-5084-e654-44c6">Assault 4+, Heavy Weapon</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="da6b-9ea6-5c21-092d" name="MG34 team (Unit)" hidden="false" typeId="0917-e2f0-0c3e-b482" typeName="Infantry Unit">
+      <modifiers>
+        <modifier type="set" field="name" value="MG34 team"/>
+      </modifiers>
+      <characteristics>
+        <characteristic name="Motivation" typeId="4aa0-1b18-70af-9474">4+ Last Stand3+</characteristic>
+        <characteristic name="Skill" typeId="7258-881d-dc2d-e80b">3+</characteristic>
+        <characteristic name="Is Hit On" typeId="0641-f39f-6a33-7dcc">4+</characteristic>
+        <characteristic name="Save" typeId="4750-979d-b2bb-c536">3+</characteristic>
+        <characteristic name="Tactical" typeId="8027-bcf9-d953-3740">8&quot;/20cm</characteristic>
+        <characteristic name="Terrain Dash" typeId="b93a-5d61-9a77-50cc">8&quot;/20cm</characteristic>
+        <characteristic name="Cross Country Dash" typeId="4862-29d4-9ab9-76a0">12&quot;/30cm</characteristic>
+        <characteristic name="Road Dash" typeId="75e3-9f15-03c8-7f95">12&quot;/30cm</characteristic>
+        <characteristic name="Cross" typeId="2d03-7d6c-d869-db3f">AUTO</characteristic>
+        <characteristic name="Notes" typeId="173e-6395-d37b-31a2"/>
+      </characteristics>
+    </profile>
+    <profile id="d223-f581-fdc0-afbc" name="5cm gun [Unit]" hidden="false" typeId="7c70-b6af-9e5a-e7f6" typeName="Gun Unit">
+      <modifiers>
+        <modifier type="set" field="name" value="5cm gun"/>
+      </modifiers>
+      <characteristics>
+        <characteristic name="Motivation" typeId="0954-f596-53ea-4ef7">4+ Last Stand 3+</characteristic>
+        <characteristic name="Skill" typeId="a907-592d-ab2d-5ead">3+ Assault 4+</characteristic>
+        <characteristic name="Is Hit On" typeId="1f89-085b-464b-c60f">4+</characteristic>
+        <characteristic name="Save" typeId="ae14-5890-03de-a715">3+</characteristic>
+        <characteristic name="Tactical" typeId="3bad-79bd-27aa-4539">4&quot;/10cm</characteristic>
+        <characteristic name="Terrain Dash" typeId="a400-d543-6fb9-26d0">4&quot;/10cm</characteristic>
+        <characteristic name="Cross Country Dash" typeId="34ca-877a-8ffa-1006">6&quot;/15cm</characteristic>
+        <characteristic name="Road Dash" typeId="d283-e066-839c-fbd7">8&quot;/20cm</characteristic>
+        <characteristic name="Cross" typeId="3f9c-89f9-0b29-0585">3+</characteristic>
+        <characteristic name="Notes" typeId="28aa-390d-006a-1776"/>
+      </characteristics>
+    </profile>
+    <profile id="dd70-41d8-f946-6066" name="5cm gun [Weapon]" hidden="false" typeId="33b6-a72a-2bd8-2565" typeName="Weapon">
+      <modifiers>
+        <modifier type="set" field="name" value="5cm gun"/>
+      </modifiers>
+      <characteristics>
+        <characteristic name="Range" typeId="c2e5-4990-8105-f793">28&quot;/70cm</characteristic>
+        <characteristic name="Halted ROF" typeId="7f6e-6f8f-5f15-6e9d">2</characteristic>
+        <characteristic name="Moving ROF" typeId="f78e-b583-b3a5-754a">1</characteristic>
+        <characteristic name="Anti-Tank" typeId="f57e-fa10-d0f9-e2dd">9</characteristic>
+        <characteristic name="Firepower" typeId="9cf3-a34f-60d9-1309">4+</characteristic>
+        <characteristic name="Notes" typeId="d939-5084-e654-44c6">Forward Firing</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="9e0f-d18b-6774-05a6" name="Sd Kfz 10/4 (2cm) [Unit]" hidden="false" typeId="7cf5-5c36-14cc-3c0d" typeName="Unarmoured Tank Unit">
+      <modifiers>
+        <modifier type="set" field="name" value="Sd Kfz 10/4 (2cm)"/>
+      </modifiers>
+      <characteristics>
+        <characteristic name="Motivation" typeId="55ef-8653-887d-4642">4+ Last Stand 3+</characteristic>
+        <characteristic name="Skill" typeId="229c-c44f-2910-c1d1">3+</characteristic>
+        <characteristic name="Is Hit On" typeId="acbb-3bc2-c667-6e4d">4+</characteristic>
+        <characteristic name="Save" typeId="6e6b-7d9e-7557-43cd">4+</characteristic>
+        <characteristic name="Tactical" typeId="6caa-857a-dce7-e965">10&quot;/25cm</characteristic>
+        <characteristic name="Terrain Dash" typeId="f188-5e37-f014-5069">12&quot;/30cm</characteristic>
+        <characteristic name="Cross Country Dash" typeId="d2da-b73b-7a4a-ca53">18&quot;/45cm</characteristic>
+        <characteristic name="Road Dash" typeId="271f-e64c-128c-5740">32&quot;/80cm</characteristic>
+        <characteristic name="Cross" typeId="b443-5f9e-d0b5-48b0">4+</characteristic>
+        <characteristic name="Notes" typeId="5c4c-b4d7-c2d1-6a93"/>
+      </characteristics>
+    </profile>
+    <profile id="12cd-6760-0e39-16c0" name="Sd Kfz 10/4 (2cm) [Weapon]" hidden="false" typeId="33b6-a72a-2bd8-2565" typeName="Weapon">
+      <modifiers>
+        <modifier type="set" field="name" value="Sd Kfz 10/4 (2cm)"/>
+      </modifiers>
+      <characteristics>
+        <characteristic name="Range" typeId="c2e5-4990-8105-f793">20&quot;/50cm</characteristic>
+        <characteristic name="Halted ROF" typeId="7f6e-6f8f-5f15-6e9d">3</characteristic>
+        <characteristic name="Moving ROF" typeId="f78e-b583-b3a5-754a">2</characteristic>
+        <characteristic name="Anti-Tank" typeId="f57e-fa10-d0f9-e2dd">5</characteristic>
+        <characteristic name="Firepower" typeId="9cf3-a34f-60d9-1309">5+</characteristic>
+        <characteristic name="Notes" typeId="d939-5084-e654-44c6">Dedicated AA</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="ed37-ed58-11d6-dd04" name="Tiger (8.8cm) [Weapon]" hidden="false" typeId="33b6-a72a-2bd8-2565" typeName="Weapon">
+      <modifiers>
+        <modifier type="set" field="name" value="Tiger (8.8cm)"/>
+      </modifiers>
+      <characteristics>
+        <characteristic name="Range" typeId="c2e5-4990-8105-f793">40&quot;/100cm</characteristic>
+        <characteristic name="Halted ROF" typeId="7f6e-6f8f-5f15-6e9d">2</characteristic>
+        <characteristic name="Moving ROF" typeId="f78e-b583-b3a5-754a">1</characteristic>
+        <characteristic name="Anti-Tank" typeId="f57e-fa10-d0f9-e2dd">14</characteristic>
+        <characteristic name="Firepower" typeId="9cf3-a34f-60d9-1309">3+</characteristic>
+        <characteristic name="Notes" typeId="d939-5084-e654-44c6"/>
+      </characteristics>
+    </profile>
+    <profile id="e920-43c0-80c1-e94c" name="Tiger (MGs)" hidden="false" typeId="33b6-a72a-2bd8-2565" typeName="Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="c2e5-4990-8105-f793">16&quot;/40cm</characteristic>
+        <characteristic name="Halted ROF" typeId="7f6e-6f8f-5f15-6e9d">4</characteristic>
+        <characteristic name="Moving ROF" typeId="f78e-b583-b3a5-754a">4</characteristic>
+        <characteristic name="Anti-Tank" typeId="f57e-fa10-d0f9-e2dd">2</characteristic>
+        <characteristic name="Firepower" typeId="9cf3-a34f-60d9-1309">6</characteristic>
+        <characteristic name="Notes" typeId="d939-5084-e654-44c6"/>
+      </characteristics>
+    </profile>
+    <profile id="6184-56a0-7f08-ca58" name="Tiger (8.8cm) [Unit]" hidden="false" typeId="55ec-3ef5-ca51-e647" typeName="Tank Unit">
+      <modifiers>
+        <modifier type="set" field="name" value="Tiger (8.8cm)"/>
+      </modifiers>
+      <characteristics>
+        <characteristic name="Motivation" typeId="046a-7f27-8072-dedb">4+ Last Stand 2+ Remount 2+</characteristic>
+        <characteristic name="Skill" typeId="6334-745a-f712-a0aa">3+</characteristic>
+        <characteristic name="Is Hit On" typeId="3931-565d-e382-fda5">4+</characteristic>
+        <characteristic name="Armour Front" typeId="b88a-3ca6-9b40-ff73">9</characteristic>
+        <characteristic name="Armour Side &amp; Rear" typeId="3712-51b3-aae3-94bd">8</characteristic>
+        <characteristic name="Armour Top" typeId="f551-1392-03e8-967d">2</characteristic>
+        <characteristic name="Tactical" typeId="ea9a-bf7d-68c5-e2d7">10&quot;/25cm</characteristic>
+        <characteristic name="Terrain Dash" typeId="f7f4-9e66-c9ed-034b">12&quot;/30cm</characteristic>
+        <characteristic name="Cross Country Dash" typeId="f73b-6fcf-b0d1-fde4">16&quot;/40cm</characteristic>
+        <characteristic name="Road Dash" typeId="b5b1-c829-470a-af62">18&quot;/45cm</characteristic>
+        <characteristic name="Cross" typeId="8be2-d5b6-ec4a-76d9">3+</characteristic>
+        <characteristic name="Notes" typeId="33d6-6375-9564-9985"/>
+      </characteristics>
+    </profile>
+    <profile id="2bf7-c313-c8d1-5c96" name="Marder (7.62cm) [Unit]" hidden="false" typeId="55ec-3ef5-ca51-e647" typeName="Tank Unit">
+      <modifiers>
+        <modifier type="set" field="name" value="Marder (7.62cm)"/>
+      </modifiers>
+      <characteristics>
+        <characteristic name="Motivation" typeId="046a-7f27-8072-dedb">4+ Counterattack 6 Last Stand 3+</characteristic>
+        <characteristic name="Skill" typeId="6334-745a-f712-a0aa">3+ Assault 5+</characteristic>
+        <characteristic name="Is Hit On" typeId="3931-565d-e382-fda5">4+</characteristic>
+        <characteristic name="Armour Front" typeId="b88a-3ca6-9b40-ff73">2</characteristic>
+        <characteristic name="Armour Side &amp; Rear" typeId="3712-51b3-aae3-94bd">1</characteristic>
+        <characteristic name="Armour Top" typeId="f551-1392-03e8-967d">0</characteristic>
+        <characteristic name="Tactical" typeId="ea9a-bf7d-68c5-e2d7">10&quot;/25cm</characteristic>
+        <characteristic name="Terrain Dash" typeId="f7f4-9e66-c9ed-034b">12&quot;/30cm</characteristic>
+        <characteristic name="Cross Country Dash" typeId="f73b-6fcf-b0d1-fde4">18&quot;/45cm</characteristic>
+        <characteristic name="Road Dash" typeId="b5b1-c829-470a-af62">20&quot;/50cm</characteristic>
+        <characteristic name="Cross" typeId="8be2-d5b6-ec4a-76d9">4+</characteristic>
+        <characteristic name="Notes" typeId="33d6-6375-9564-9985"/>
+      </characteristics>
+    </profile>
+    <profile id="f210-c183-8e8c-ce85" name="Marder (7.62cm) [Weapon]" hidden="false" typeId="33b6-a72a-2bd8-2565" typeName="Weapon">
+      <modifiers>
+        <modifier type="set" field="name" value="Marder (7.62cm)"/>
+      </modifiers>
+      <characteristics>
+        <characteristic name="Range" typeId="c2e5-4990-8105-f793">32&quot;/80cm</characteristic>
+        <characteristic name="Halted ROF" typeId="7f6e-6f8f-5f15-6e9d">2</characteristic>
+        <characteristic name="Moving ROF" typeId="f78e-b583-b3a5-754a">1</characteristic>
+        <characteristic name="Anti-Tank" typeId="f57e-fa10-d0f9-e2dd">12</characteristic>
+        <characteristic name="Firepower" typeId="9cf3-a34f-60d9-1309">3+</characteristic>
+        <characteristic name="Notes" typeId="d939-5084-e654-44c6">Forward Firing</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="97b0-83cc-f31b-4736" name="Marder (MG)" hidden="false" typeId="33b6-a72a-2bd8-2565" typeName="Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="c2e5-4990-8105-f793">16&quot;/40cm</characteristic>
+        <characteristic name="Halted ROF" typeId="7f6e-6f8f-5f15-6e9d">3</characteristic>
+        <characteristic name="Moving ROF" typeId="f78e-b583-b3a5-754a">3</characteristic>
+        <characteristic name="Anti-Tank" typeId="f57e-fa10-d0f9-e2dd">2</characteristic>
+        <characteristic name="Firepower" typeId="9cf3-a34f-60d9-1309">6</characteristic>
+        <characteristic name="Notes" typeId="d939-5084-e654-44c6">Forward Firing</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="c984-7646-3ae3-a803" name="8.8cm AA gun" hidden="false" typeId="33b6-a72a-2bd8-2565" typeName="Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="c2e5-4990-8105-f793">40&quot;/100cm</characteristic>
+        <characteristic name="Halted ROF" typeId="7f6e-6f8f-5f15-6e9d">2</characteristic>
+        <characteristic name="Moving ROF" typeId="f78e-b583-b3a5-754a">1</characteristic>
+        <characteristic name="Anti-Tank" typeId="f57e-fa10-d0f9-e2dd">14</characteristic>
+        <characteristic name="Firepower" typeId="9cf3-a34f-60d9-1309">3+</characteristic>
+        <characteristic name="Notes" typeId="d939-5084-e654-44c6">Self-defence AA</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="215d-c40a-ac50-2433" name="8.8cm AA gun" hidden="false" typeId="7c70-b6af-9e5a-e7f6" typeName="Gun Unit">
+      <characteristics>
+        <characteristic name="Motivation" typeId="0954-f596-53ea-4ef7">4+ Last Stand 3+</characteristic>
+        <characteristic name="Skill" typeId="a907-592d-ab2d-5ead">3+ Assault 4+</characteristic>
+        <characteristic name="Is Hit On" typeId="1f89-085b-464b-c60f">4+</characteristic>
+        <characteristic name="Save" typeId="ae14-5890-03de-a715">4+</characteristic>
+        <characteristic name="Tactical" typeId="3bad-79bd-27aa-4539">-</characteristic>
+        <characteristic name="Terrain Dash" typeId="a400-d543-6fb9-26d0">2&quot;/5cm</characteristic>
+        <characteristic name="Cross Country Dash" typeId="34ca-877a-8ffa-1006">4&quot;/10cm</characteristic>
+        <characteristic name="Road Dash" typeId="d283-e066-839c-fbd7">4&quot;/10cm</characteristic>
+        <characteristic name="Cross" typeId="3f9c-89f9-0b29-0585">6</characteristic>
+        <characteristic name="Notes" typeId="28aa-390d-006a-1776"/>
+      </characteristics>
+    </profile>
+    <profile id="b9c5-805b-4d8e-f2e2" name="Sd Kfz 222 &amp; 221 [Unit]" hidden="false" typeId="55ec-3ef5-ca51-e647" typeName="Tank Unit">
+      <modifiers>
+        <modifier type="set" field="name" value="Sd Kfz 222 &amp; 221 "/>
+      </modifiers>
+      <characteristics>
+        <characteristic name="Motivation" typeId="046a-7f27-8072-dedb">5+ Counterattack 6 Remount 4+</characteristic>
+        <characteristic name="Skill" typeId="6334-745a-f712-a0aa">3+ Assault 4+</characteristic>
+        <characteristic name="Is Hit On" typeId="3931-565d-e382-fda5">4+</characteristic>
+        <characteristic name="Armour Front" typeId="b88a-3ca6-9b40-ff73">1</characteristic>
+        <characteristic name="Armour Side &amp; Rear" typeId="3712-51b3-aae3-94bd">0</characteristic>
+        <characteristic name="Armour Top" typeId="f551-1392-03e8-967d">0</characteristic>
+        <characteristic name="Tactical" typeId="ea9a-bf7d-68c5-e2d7">10&quot;/25cm</characteristic>
+        <characteristic name="Terrain Dash" typeId="f7f4-9e66-c9ed-034b">10&quot;/25cm</characteristic>
+        <characteristic name="Cross Country Dash" typeId="f73b-6fcf-b0d1-fde4">16&quot;/40cm</characteristic>
+        <characteristic name="Road Dash" typeId="b5b1-c829-470a-af62">40&quot;/100cm</characteristic>
+        <characteristic name="Cross" typeId="8be2-d5b6-ec4a-76d9">4+</characteristic>
+        <characteristic name="Notes" typeId="33d6-6375-9564-9985"/>
+      </characteristics>
+    </profile>
+    <profile id="e83c-fc97-c1fb-9577" name="Sd Kfz 222 (2cm)" hidden="false" typeId="33b6-a72a-2bd8-2565" typeName="Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="c2e5-4990-8105-f793">20&quot;/50cm</characteristic>
+        <characteristic name="Halted ROF" typeId="7f6e-6f8f-5f15-6e9d">3</characteristic>
+        <characteristic name="Moving ROF" typeId="f78e-b583-b3a5-754a">2</characteristic>
+        <characteristic name="Anti-Tank" typeId="f57e-fa10-d0f9-e2dd">5</characteristic>
+        <characteristic name="Firepower" typeId="9cf3-a34f-60d9-1309">5+</characteristic>
+        <characteristic name="Notes" typeId="d939-5084-e654-44c6">Self-defence AA</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="c190-2257-2267-8970" name="Sd Kfz 222 &amp; 221 (MG)" hidden="false" typeId="33b6-a72a-2bd8-2565" typeName="Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="c2e5-4990-8105-f793">16&quot;/40cm</characteristic>
+        <characteristic name="Halted ROF" typeId="7f6e-6f8f-5f15-6e9d">3</characteristic>
+        <characteristic name="Moving ROF" typeId="f78e-b583-b3a5-754a">3</characteristic>
+        <characteristic name="Anti-Tank" typeId="f57e-fa10-d0f9-e2dd">2</characteristic>
+        <characteristic name="Firepower" typeId="9cf3-a34f-60d9-1309">6</characteristic>
+        <characteristic name="Notes" typeId="d939-5084-e654-44c6">Self-defence AA</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="269b-6001-8015-8bcc" name="Sd Kfz 221 (2.8cm)" hidden="false" typeId="33b6-a72a-2bd8-2565" typeName="Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="c2e5-4990-8105-f793">20&quot;/50cm</characteristic>
+        <characteristic name="Halted ROF" typeId="7f6e-6f8f-5f15-6e9d">1</characteristic>
+        <characteristic name="Moving ROF" typeId="f78e-b583-b3a5-754a">1</characteristic>
+        <characteristic name="Anti-Tank" typeId="f57e-fa10-d0f9-e2dd">7</characteristic>
+        <characteristic name="Firepower" typeId="9cf3-a34f-60d9-1309">5+</characteristic>
+        <characteristic name="Notes" typeId="d939-5084-e654-44c6">Forward Firing, No HE, Slow Firing</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="4506-81fb-f1a0-3897" name="Sd Kfz 231 (2cm) [Weapon]" hidden="false" typeId="33b6-a72a-2bd8-2565" typeName="Weapon">
+      <modifiers>
+        <modifier type="set" field="name" value="Sd Kfz 231 (2cm) "/>
+      </modifiers>
+      <characteristics>
+        <characteristic name="Range" typeId="c2e5-4990-8105-f793">20&quot;/50cm</characteristic>
+        <characteristic name="Halted ROF" typeId="7f6e-6f8f-5f15-6e9d">3</characteristic>
+        <characteristic name="Moving ROF" typeId="f78e-b583-b3a5-754a">2</characteristic>
+        <characteristic name="Anti-Tank" typeId="f57e-fa10-d0f9-e2dd">5</characteristic>
+        <characteristic name="Firepower" typeId="9cf3-a34f-60d9-1309">5+</characteristic>
+        <characteristic name="Notes" typeId="d939-5084-e654-44c6"/>
+      </characteristics>
+    </profile>
+    <profile id="a039-177e-54a8-ff1b" name="Sd Kfz 231 (MG)" hidden="false" typeId="33b6-a72a-2bd8-2565" typeName="Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="c2e5-4990-8105-f793">16&quot;/40cm</characteristic>
+        <characteristic name="Halted ROF" typeId="7f6e-6f8f-5f15-6e9d">3</characteristic>
+        <characteristic name="Moving ROF" typeId="f78e-b583-b3a5-754a">3</characteristic>
+        <characteristic name="Anti-Tank" typeId="f57e-fa10-d0f9-e2dd">2</characteristic>
+        <characteristic name="Firepower" typeId="9cf3-a34f-60d9-1309">6</characteristic>
+        <characteristic name="Notes" typeId="d939-5084-e654-44c6"/>
+      </characteristics>
+    </profile>
+    <profile id="0656-168a-fde7-645a" name="Sd Kfz 231 (2cm) [Unit]" hidden="false" typeId="55ec-3ef5-ca51-e647" typeName="Tank Unit">
+      <modifiers>
+        <modifier type="set" field="name" value="Sd Kfz 231 (2cm) "/>
+      </modifiers>
+      <characteristics>
+        <characteristic name="Motivation" typeId="046a-7f27-8072-dedb">5+ Counterattack 6 Remount 4+</characteristic>
+        <characteristic name="Skill" typeId="6334-745a-f712-a0aa">3+ Assault 4+</characteristic>
+        <characteristic name="Is Hit On" typeId="3931-565d-e382-fda5">4+</characteristic>
+        <characteristic name="Armour Front" typeId="b88a-3ca6-9b40-ff73">3</characteristic>
+        <characteristic name="Armour Side &amp; Rear" typeId="3712-51b3-aae3-94bd">1</characteristic>
+        <characteristic name="Armour Top" typeId="f551-1392-03e8-967d">0</characteristic>
+        <characteristic name="Tactical" typeId="ea9a-bf7d-68c5-e2d7">10&quot;/25cm</characteristic>
+        <characteristic name="Terrain Dash" typeId="f7f4-9e66-c9ed-034b">12&quot;/30cm</characteristic>
+        <characteristic name="Cross Country Dash" typeId="f73b-6fcf-b0d1-fde4">18&quot;/45cm</characteristic>
+        <characteristic name="Road Dash" typeId="b5b1-c829-470a-af62">40&quot;/100cm</characteristic>
+        <characteristic name="Cross" typeId="8be2-d5b6-ec4a-76d9">4+</characteristic>
+        <characteristic name="Notes" typeId="33d6-6375-9564-9985"/>
+      </characteristics>
+    </profile>
+    <profile id="fc6b-e27c-2d3d-fee2" name="Panzer II OP" hidden="false" typeId="55ec-3ef5-ca51-e647" typeName="Tank Unit">
+      <characteristics>
+        <characteristic name="Motivation" typeId="046a-7f27-8072-dedb">4+ / 5+ Last Stand / 6 Counterattack </characteristic>
+        <characteristic name="Skill" typeId="6334-745a-f712-a0aa">3+</characteristic>
+        <characteristic name="Is Hit On" typeId="3931-565d-e382-fda5">4+</characteristic>
+        <characteristic name="Armour Front" typeId="b88a-3ca6-9b40-ff73">3</characteristic>
+        <characteristic name="Armour Side &amp; Rear" typeId="3712-51b3-aae3-94bd">1</characteristic>
+        <characteristic name="Armour Top" typeId="f551-1392-03e8-967d">1</characteristic>
+        <characteristic name="Tactical" typeId="ea9a-bf7d-68c5-e2d7">10&quot;/25cm</characteristic>
+        <characteristic name="Terrain Dash" typeId="f7f4-9e66-c9ed-034b">12&quot;/30cm</characteristic>
+        <characteristic name="Cross Country Dash" typeId="f73b-6fcf-b0d1-fde4">18&quot;/45cm</characteristic>
+        <characteristic name="Road Dash" typeId="b5b1-c829-470a-af62">20&quot;/50cm</characteristic>
+        <characteristic name="Cross" typeId="8be2-d5b6-ec4a-76d9">3+</characteristic>
+        <characteristic name="Notes" typeId="33d6-6375-9564-9985"/>
+      </characteristics>
+    </profile>
+    <profile id="9fec-a2fe-7262-a9fc" name="Panzer II (2cm) [Weapon]" hidden="false" typeId="33b6-a72a-2bd8-2565" typeName="Weapon">
+      <modifiers>
+        <modifier type="set" field="name" value="Panzer II (2cm)"/>
+      </modifiers>
+      <characteristics>
+        <characteristic name="Range" typeId="c2e5-4990-8105-f793">20&quot;/50cm</characteristic>
+        <characteristic name="Halted ROF" typeId="7f6e-6f8f-5f15-6e9d">1</characteristic>
+        <characteristic name="Moving ROF" typeId="f78e-b583-b3a5-754a">1</characteristic>
+        <characteristic name="Anti-Tank" typeId="f57e-fa10-d0f9-e2dd">5</characteristic>
+        <characteristic name="Firepower" typeId="9cf3-a34f-60d9-1309">5+</characteristic>
+        <characteristic name="Notes" typeId="d939-5084-e654-44c6"/>
+      </characteristics>
+    </profile>
+    <profile id="32af-b10e-13da-282b" name="10.5cm howitzer" hidden="false" typeId="7c70-b6af-9e5a-e7f6" typeName="Gun Unit">
+      <characteristics>
+        <characteristic name="Motivation" typeId="0954-f596-53ea-4ef7">4+ Last Stand 3+</characteristic>
+        <characteristic name="Skill" typeId="a907-592d-ab2d-5ead">3+ Assault 4+</characteristic>
+        <characteristic name="Is Hit On" typeId="1f89-085b-464b-c60f">4+</characteristic>
+        <characteristic name="Save" typeId="ae14-5890-03de-a715">4+</characteristic>
+        <characteristic name="Tactical" typeId="3bad-79bd-27aa-4539">-</characteristic>
+        <characteristic name="Terrain Dash" typeId="a400-d543-6fb9-26d0">2&quot;/5cm</characteristic>
+        <characteristic name="Cross Country Dash" typeId="34ca-877a-8ffa-1006">4&quot;/10cm</characteristic>
+        <characteristic name="Road Dash" typeId="d283-e066-839c-fbd7">4&quot;/10cm</characteristic>
+        <characteristic name="Cross" typeId="3f9c-89f9-0b29-0585">6</characteristic>
+        <characteristic name="Notes" typeId="28aa-390d-006a-1776"/>
+      </characteristics>
+    </profile>
+    <profile id="3de8-6ce7-b2a1-e6b8" name="10.5cm howitzer [Artillery]" hidden="false" typeId="33b6-a72a-2bd8-2565" typeName="Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="c2e5-4990-8105-f793">72&quot;/180cm</characteristic>
+        <characteristic name="Halted ROF" typeId="7f6e-6f8f-5f15-6e9d">ARTILLERY</characteristic>
+        <characteristic name="Moving ROF" typeId="f78e-b583-b3a5-754a"/>
+        <characteristic name="Anti-Tank" typeId="f57e-fa10-d0f9-e2dd">3</characteristic>
+        <characteristic name="Firepower" typeId="9cf3-a34f-60d9-1309">3+</characteristic>
+        <characteristic name="Notes" typeId="d939-5084-e654-44c6">Forward Firing, Smoke Bombardment</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="b05f-ec9a-abc8-3b66" name="10.5cm howitzer [Direct Fire]" hidden="false" typeId="33b6-a72a-2bd8-2565" typeName="Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="c2e5-4990-8105-f793">24&quot;/60cm</characteristic>
+        <characteristic name="Halted ROF" typeId="7f6e-6f8f-5f15-6e9d">1</characteristic>
+        <characteristic name="Moving ROF" typeId="f78e-b583-b3a5-754a">1</characteristic>
+        <characteristic name="Anti-Tank" typeId="f57e-fa10-d0f9-e2dd">9</characteristic>
+        <characteristic name="Firepower" typeId="9cf3-a34f-60d9-1309">2+</characteristic>
+        <characteristic name="Notes" typeId="d939-5084-e654-44c6">Brutal, Forward Firing, Slow Firing, Smoke</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="26b6-6573-5075-a1fb" name="15cm (Sf) Lorraine Schlepper" hidden="false" typeId="55ec-3ef5-ca51-e647" typeName="Tank Unit">
+      <characteristics>
+        <characteristic name="Motivation" typeId="046a-7f27-8072-dedb">4+ Counterattack 6 Last Stand 3+</characteristic>
+        <characteristic name="Skill" typeId="6334-745a-f712-a0aa">3+ Assault 5+</characteristic>
+        <characteristic name="Is Hit On" typeId="3931-565d-e382-fda5">4+</characteristic>
+        <characteristic name="Armour Front" typeId="b88a-3ca6-9b40-ff73">1</characteristic>
+        <characteristic name="Armour Side &amp; Rear" typeId="3712-51b3-aae3-94bd">1</characteristic>
+        <characteristic name="Armour Top" typeId="f551-1392-03e8-967d">0</characteristic>
+        <characteristic name="Tactical" typeId="ea9a-bf7d-68c5-e2d7">8&quot;/20cm</characteristic>
+        <characteristic name="Terrain Dash" typeId="f7f4-9e66-c9ed-034b">10&quot;/25cm</characteristic>
+        <characteristic name="Cross Country Dash" typeId="f73b-6fcf-b0d1-fde4">14&quot;/35cm</characteristic>
+        <characteristic name="Road Dash" typeId="b5b1-c829-470a-af62">16&quot;/40cm</characteristic>
+        <characteristic name="Cross" typeId="8be2-d5b6-ec4a-76d9">3+</characteristic>
+        <characteristic name="Notes" typeId="33d6-6375-9564-9985"/>
+      </characteristics>
+    </profile>
+    <profile id="bf6e-857c-43d5-4c58" name="15cm (Sf) howitzer [Artillery]" hidden="false" typeId="33b6-a72a-2bd8-2565" typeName="Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="c2e5-4990-8105-f793">64&quot;/160cm</characteristic>
+        <characteristic name="Halted ROF" typeId="7f6e-6f8f-5f15-6e9d">ARTILLERY</characteristic>
+        <characteristic name="Moving ROF" typeId="f78e-b583-b3a5-754a"/>
+        <characteristic name="Anti-Tank" typeId="f57e-fa10-d0f9-e2dd">3</characteristic>
+        <characteristic name="Firepower" typeId="9cf3-a34f-60d9-1309">2+</characteristic>
+        <characteristic name="Notes" typeId="d939-5084-e654-44c6">Forward Firing</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="005f-4755-c31f-3075" name="15cm (Sf) howitzer [Direct Fire]" hidden="false" typeId="33b6-a72a-2bd8-2565" typeName="Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="c2e5-4990-8105-f793">16&quot;/40cm</characteristic>
+        <characteristic name="Halted ROF" typeId="7f6e-6f8f-5f15-6e9d">1</characteristic>
+        <characteristic name="Moving ROF" typeId="f78e-b583-b3a5-754a">-</characteristic>
+        <characteristic name="Anti-Tank" typeId="f57e-fa10-d0f9-e2dd">9</characteristic>
+        <characteristic name="Firepower" typeId="9cf3-a34f-60d9-1309">AUTO</characteristic>
+        <characteristic name="Notes" typeId="d939-5084-e654-44c6">Brutal, Forward Firing</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="1303-568a-38b7-564d" name="Ju 87 Stuka" hidden="false" typeId="d8ed-85c5-35d4-eb3c" typeName="Aircraft Unit">
+      <characteristics>
+        <characteristic name="Motivation" typeId="ec3b-729b-2af4-7bed">4+</characteristic>
+        <characteristic name="Skill" typeId="e506-9161-836a-5e2d">3+</characteristic>
+        <characteristic name="Is Hit On" typeId="9691-8132-58f7-5f86">5+</characteristic>
+        <characteristic name="Save" typeId="3a7a-29d5-008e-09f7">3+</characteristic>
+        <characteristic name="Tactical" typeId="8791-6355-ebcf-f430">UNLIMITED</characteristic>
+        <characteristic name="Terrain Dash" typeId="e6d2-8608-f213-ef1f"/>
+        <characteristic name="Cross Country Dash" typeId="037d-b1be-ca62-5c3e"/>
+        <characteristic name="Road Dash" typeId="207b-99f1-9a35-12d8"/>
+        <characteristic name="Cross" typeId="07b3-6909-7897-f282">AUTO</characteristic>
+        <characteristic name="Notes" typeId="8252-ebff-91e7-47ea"/>
+      </characteristics>
+    </profile>
+    <profile id="5634-09d2-861f-5791" name="500kg bombs" hidden="false" typeId="33b6-a72a-2bd8-2565" typeName="Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="c2e5-4990-8105-f793">6&quot;/15cm</characteristic>
+        <characteristic name="Halted ROF" typeId="7f6e-6f8f-5f15-6e9d">ARTILLERY</characteristic>
+        <characteristic name="Moving ROF" typeId="f78e-b583-b3a5-754a"/>
+        <characteristic name="Anti-Tank" typeId="f57e-fa10-d0f9-e2dd">4</characteristic>
+        <characteristic name="Firepower" typeId="9cf3-a34f-60d9-1309">2+</characteristic>
+        <characteristic name="Notes" typeId="d939-5084-e654-44c6">Bombs</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="51f8-e73b-26df-0797" name="Panzer IV" hidden="false" typeId="55ec-3ef5-ca51-e647" typeName="Tank Unit">
+      <characteristics>
+        <characteristic name="Motivation" typeId="046a-7f27-8072-dedb">4+ / 3+ Last Stand / 3+ Remount</characteristic>
+        <characteristic name="Skill" typeId="6334-745a-f712-a0aa">3+</characteristic>
+        <characteristic name="Is Hit On" typeId="3931-565d-e382-fda5">4+</characteristic>
+        <characteristic name="Armour Front" typeId="b88a-3ca6-9b40-ff73">5</characteristic>
+        <characteristic name="Armour Side &amp; Rear" typeId="3712-51b3-aae3-94bd">3</characteristic>
+        <characteristic name="Armour Top" typeId="f551-1392-03e8-967d">1</characteristic>
+        <characteristic name="Tactical" typeId="ea9a-bf7d-68c5-e2d7">10&quot;/25cm</characteristic>
+        <characteristic name="Terrain Dash" typeId="f7f4-9e66-c9ed-034b">14&quot;/35cm</characteristic>
+        <characteristic name="Cross Country Dash" typeId="f73b-6fcf-b0d1-fde4">18&quot;/45cm</characteristic>
+        <characteristic name="Road Dash" typeId="b5b1-c829-470a-af62">20&quot;/50cm</characteristic>
+        <characteristic name="Cross" typeId="8be2-d5b6-ec4a-76d9">3+</characteristic>
+        <characteristic name="Notes" typeId="33d6-6375-9564-9985"/>
+      </characteristics>
+    </profile>
+  </sharedProfiles>
+  <catalogueLinks>
+    <catalogueLink id="f63a-e78f-47e5-b939" name="Mid-War; Fallschirmjager" targetId="4e61-1b9e-452b-7fe1" type="catalogue" importRootEntries="true"/>
+  </catalogueLinks>
+</catalogue>

--- a/Mid-War; Fallschirmjager.cat
+++ b/Mid-War; Fallschirmjager.cat
@@ -1,0 +1,985 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<catalogue id="4e61-1b9e-452b-7fe1" name="Mid-War; Fallschirmjager" revision="1" battleScribeVersion="2.03" authorName="UrsinePatriarch" authorContact="Discord: zharrpostingghoroth" library="true" gameSystemId="976a-b687-1fdb-07ef" gameSystemRevision="25" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+  <sharedSelectionEntries>
+    <selectionEntry id="ee5b-b00a-238f-0dac" name="Fallschirmjager 10.5cm Recoilless Battery" hidden="false" collective="false" import="true" type="unit">
+      <profiles>
+        <profile id="12fa-0239-e599-3301" name="10.5cm Recoilless Team" hidden="false" typeId="7c70-b6af-9e5a-e7f6" typeName="Gun Unit">
+          <characteristics>
+            <characteristic name="Motivation" typeId="0954-f596-53ea-4ef7">3+</characteristic>
+            <characteristic name="Skill" typeId="a907-592d-ab2d-5ead">3+ / 4+ Assault</characteristic>
+            <characteristic name="Is Hit On" typeId="1f89-085b-464b-c60f">4+</characteristic>
+            <characteristic name="Save" typeId="ae14-5890-03de-a715">4+</characteristic>
+            <characteristic name="Tactical" typeId="3bad-79bd-27aa-4539">4&quot;/10cm</characteristic>
+            <characteristic name="Terrain Dash" typeId="a400-d543-6fb9-26d0">4&quot;/10cm</characteristic>
+            <characteristic name="Cross Country Dash" typeId="34ca-877a-8ffa-1006">6&quot;/15cm</characteristic>
+            <characteristic name="Road Dash" typeId="d283-e066-839c-fbd7">8&quot;/20cm</characteristic>
+            <characteristic name="Cross" typeId="3f9c-89f9-0b29-0585">3+</characteristic>
+            <characteristic name="Notes" typeId="28aa-390d-006a-1776"/>
+          </characteristics>
+        </profile>
+        <profile id="152b-ca2e-9751-febd" name="10.5cm recoilless gun [Artillery]" hidden="false" typeId="33b6-a72a-2bd8-2565" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="c2e5-4990-8105-f793">64&quot;/160cm</characteristic>
+            <characteristic name="Halted ROF" typeId="7f6e-6f8f-5f15-6e9d">ARTILLERY</characteristic>
+            <characteristic name="Moving ROF" typeId="f78e-b583-b3a5-754a"/>
+            <characteristic name="Anti-Tank" typeId="f57e-fa10-d0f9-e2dd">3</characteristic>
+            <characteristic name="Firepower" typeId="9cf3-a34f-60d9-1309">3+</characteristic>
+            <characteristic name="Notes" typeId="d939-5084-e654-44c6">Recoilless</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="de8c-3d72-12a3-34a4" name="10.5cm recoilless gun [Direct Fire]" hidden="false" typeId="33b6-a72a-2bd8-2565" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="c2e5-4990-8105-f793">16&quot;/40cm</characteristic>
+            <characteristic name="Halted ROF" typeId="7f6e-6f8f-5f15-6e9d">1</characteristic>
+            <characteristic name="Moving ROF" typeId="f78e-b583-b3a5-754a">1</characteristic>
+            <characteristic name="Anti-Tank" typeId="f57e-fa10-d0f9-e2dd">10</characteristic>
+            <characteristic name="Firepower" typeId="9cf3-a34f-60d9-1309">2+</characteristic>
+            <characteristic name="Notes" typeId="d939-5084-e654-44c6">Brutal, Recoilless, Slow Firing, Smoke</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="236f-4e5c-f2b7-b338" name="Smoke" hidden="false" targetId="6f51-dbfe-55b0-a6d0" type="rule"/>
+        <infoLink id="698c-11bc-0451-59ef" name="Large Gun" hidden="false" targetId="183b-aef0-86e1-693f" type="rule"/>
+        <infoLink id="8200-13d2-922d-32f3" name="Recoilless" hidden="false" targetId="104f-a2b8-aba6-fc6e" type="rule"/>
+        <infoLink id="4fbd-57cd-013a-6d75" name="Slow Firing" hidden="false" targetId="e215-d5bf-83ce-606a" type="rule"/>
+        <infoLink id="9f8a-9bce-1594-07ec" name="Brutal" hidden="false" targetId="97da-9a33-4ff1-56f2" type="rule"/>
+        <infoLink id="ffc5-9f10-55ec-f6b1" name="Gun" hidden="false" targetId="139e-9d64-28a3-a3dd" type="rule"/>
+      </infoLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="0844-acc1-06ec-800f" name="Unit Size" hidden="false" collective="false" import="true" defaultSelectionEntryId="587f-cf08-d91f-517e">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e572-d33a-e498-ceed" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6389-4686-6031-8ba6" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="587f-cf08-d91f-517e" name="2x 10.5cm recoilless gun" hidden="false" collective="false" import="true" type="upgrade">
+              <costs>
+                <cost name="pts" typeId="995a-4d67-6920-bfe4" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="0bbe-5bd9-51d1-01e7" name="4x 10.5cm recoilless gun" hidden="false" collective="false" import="true" type="upgrade">
+              <costs>
+                <cost name="pts" typeId="995a-4d67-6920-bfe4" value="20.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6307-1844-7dc9-2701" name="Fallschirmjager 3.7cm Tank-hunter Platoon" hidden="false" collective="false" import="true" type="unit">
+      <profiles>
+        <profile id="4dca-6fd3-e0f3-0297" name="3.7cm gun team" hidden="false" typeId="7c70-b6af-9e5a-e7f6" typeName="Gun Unit">
+          <characteristics>
+            <characteristic name="Motivation" typeId="0954-f596-53ea-4ef7">3+</characteristic>
+            <characteristic name="Skill" typeId="a907-592d-ab2d-5ead">3+ / 4+ Assault</characteristic>
+            <characteristic name="Is Hit On" typeId="1f89-085b-464b-c60f">4+</characteristic>
+            <characteristic name="Save" typeId="ae14-5890-03de-a715">3+</characteristic>
+            <characteristic name="Tactical" typeId="3bad-79bd-27aa-4539">4&quot;/10cm</characteristic>
+            <characteristic name="Terrain Dash" typeId="a400-d543-6fb9-26d0">4&quot;/10cm</characteristic>
+            <characteristic name="Cross Country Dash" typeId="34ca-877a-8ffa-1006">8&quot;/20cm</characteristic>
+            <characteristic name="Road Dash" typeId="d283-e066-839c-fbd7">8&quot;/20cm</characteristic>
+            <characteristic name="Cross" typeId="3f9c-89f9-0b29-0585">3+</characteristic>
+            <characteristic name="Notes" typeId="28aa-390d-006a-1776"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="a450-65f6-5ea8-c226" name="3.7cm gun" hidden="false" targetId="b1d4-463e-6275-932a" type="profile"/>
+        <infoLink id="458c-2a40-78e8-e4f8" name="Forward Firing" hidden="false" targetId="fa9d-68f6-57d9-dc5d" type="rule"/>
+        <infoLink id="c123-d6b5-f79b-f05c" name="Gun" hidden="false" targetId="139e-9d64-28a3-a3dd" type="rule"/>
+        <infoLink id="4a6c-1a1c-0c46-60c8" name="Gun Shield" hidden="false" targetId="2f2d-c5a9-ef7e-1b5e" type="rule"/>
+      </infoLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="08b4-9235-3529-c0ae" name="Unit Size" hidden="false" collective="false" import="true" defaultSelectionEntryId="cd84-4979-868e-56e0">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ccb2-9895-fc9d-790d" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bab4-a9f6-0100-d141" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="c254-bd22-705c-31f3" name="4x 3.7cm gun" hidden="false" collective="false" import="true" type="upgrade">
+              <costs>
+                <cost name="pts" typeId="995a-4d67-6920-bfe4" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="aa61-d096-f257-7788" name="3x 3.7cm gun" hidden="false" collective="false" import="true" type="upgrade">
+              <costs>
+                <cost name="pts" typeId="995a-4d67-6920-bfe4" value="7.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="cd84-4979-868e-56e0" name="2x 3.7cm gun" hidden="false" collective="false" import="true" type="upgrade">
+              <costs>
+                <cost name="pts" typeId="995a-4d67-6920-bfe4" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="701f-5f01-74b3-5266" name="4x 3.7cm (Stielgranate) gun" hidden="false" collective="false" import="true" type="upgrade">
+              <infoLinks>
+                <infoLink id="e244-9977-07d7-82db" name="3.7cm (firing Stielgranate)" hidden="false" targetId="2db5-7b6e-328f-79b2" type="profile"/>
+                <infoLink id="b947-baa2-fa1d-0843" name="Slow Firing" hidden="false" targetId="e215-d5bf-83ce-606a" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="995a-4d67-6920-bfe4" value="14.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="dcb9-ef6d-8287-f443" name="3x 3.7cm (Stielgranate) gun" hidden="false" collective="false" import="true" type="upgrade">
+              <infoLinks>
+                <infoLink id="6e15-abc6-0401-cd89" name="3.7cm (firing Stielgranate)" hidden="false" targetId="2db5-7b6e-328f-79b2" type="profile"/>
+                <infoLink id="f3e5-a137-5dfd-0da0" name="Slow Firing" hidden="false" targetId="e215-d5bf-83ce-606a" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="995a-4d67-6920-bfe4" value="11.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="610e-4f66-3848-ceb9" name="2x 3.7cm (Stielgranate) gun" hidden="false" collective="false" import="true" type="upgrade">
+              <infoLinks>
+                <infoLink id="a09a-586a-5cc2-01a8" name="3.7cm (firing Stielgranate)" hidden="false" targetId="2db5-7b6e-328f-79b2" type="profile"/>
+                <infoLink id="7a28-2de4-07ac-267c" name="Slow Firing" hidden="false" targetId="e215-d5bf-83ce-606a" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="995a-4d67-6920-bfe4" value="7.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1efc-46db-899d-7d86" name="Fallschirmjager 5cm Tank-hunter Platoon" hidden="false" collective="false" import="true" type="unit">
+      <profiles>
+        <profile id="cf5e-98ba-400d-087f" name="5cm gun team" hidden="false" typeId="7c70-b6af-9e5a-e7f6" typeName="Gun Unit">
+          <characteristics>
+            <characteristic name="Motivation" typeId="0954-f596-53ea-4ef7">3+</characteristic>
+            <characteristic name="Skill" typeId="a907-592d-ab2d-5ead">3+ / 4+ Assault</characteristic>
+            <characteristic name="Is Hit On" typeId="1f89-085b-464b-c60f">4+</characteristic>
+            <characteristic name="Save" typeId="ae14-5890-03de-a715">3+</characteristic>
+            <characteristic name="Tactical" typeId="3bad-79bd-27aa-4539">4&quot;/10cm</characteristic>
+            <characteristic name="Terrain Dash" typeId="a400-d543-6fb9-26d0">4&quot;/10cm</characteristic>
+            <characteristic name="Cross Country Dash" typeId="34ca-877a-8ffa-1006">6&quot;/15cm</characteristic>
+            <characteristic name="Road Dash" typeId="d283-e066-839c-fbd7">8&quot;/20cm</characteristic>
+            <characteristic name="Cross" typeId="3f9c-89f9-0b29-0585">3+</characteristic>
+            <characteristic name="Notes" typeId="28aa-390d-006a-1776"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="c858-aa6f-b408-542f" name="5cm gun" hidden="false" targetId="df40-6714-a072-4b05" type="profile"/>
+        <infoLink id="1765-a332-e8cd-9c2b" name="Forward Firing" hidden="false" targetId="fa9d-68f6-57d9-dc5d" type="rule"/>
+      </infoLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="2c1e-ebeb-fd8e-0793" name="Unit Size" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b002-cfa7-8c98-8fd4" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a563-8d2a-282c-1f04" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="48db-67d5-ef58-7214" name="3x 5cm gun" hidden="false" collective="false" import="true" type="upgrade">
+              <costs>
+                <cost name="pts" typeId="995a-4d67-6920-bfe4" value="14.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="7359-bae7-e3b3-3ef0" name="2x 5cm gun" hidden="false" collective="false" import="true" type="upgrade">
+              <costs>
+                <cost name="pts" typeId="995a-4d67-6920-bfe4" value="9.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="3895-f323-f347-51ea" name="4x 5cm gun" hidden="false" collective="false" import="true" type="upgrade">
+              <costs>
+                <cost name="pts" typeId="995a-4d67-6920-bfe4" value="19.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ee8c-8e4d-3a7a-25ff" name="Fallschirmjager 7.5cm Tank-Hunter Platoon" hidden="false" collective="false" import="true" type="unit">
+      <profiles>
+        <profile id="b07d-3614-d7a4-a3d3" name="7.5cm mountain gun [Artillery]" hidden="false" typeId="33b6-a72a-2bd8-2565" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="c2e5-4990-8105-f793">72&quot;/180cm</characteristic>
+            <characteristic name="Halted ROF" typeId="7f6e-6f8f-5f15-6e9d">ARTILLERY</characteristic>
+            <characteristic name="Moving ROF" typeId="f78e-b583-b3a5-754a"></characteristic>
+            <characteristic name="Anti-Tank" typeId="f57e-fa10-d0f9-e2dd">2</characteristic>
+            <characteristic name="Firepower" typeId="9cf3-a34f-60d9-1309">4+</characteristic>
+            <characteristic name="Notes" typeId="d939-5084-e654-44c6">Forward Firing, Smoke Bombardment</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="c264-cc14-4630-4cad" name="7.5cm mountain gun [Direct Fire]" hidden="false" typeId="33b6-a72a-2bd8-2565" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="c2e5-4990-8105-f793">20&quot;/50cm</characteristic>
+            <characteristic name="Halted ROF" typeId="7f6e-6f8f-5f15-6e9d">2</characteristic>
+            <characteristic name="Moving ROF" typeId="f78e-b583-b3a5-754a">1</characteristic>
+            <characteristic name="Anti-Tank" typeId="f57e-fa10-d0f9-e2dd">6</characteristic>
+            <characteristic name="Firepower" typeId="9cf3-a34f-60d9-1309">3+</characteristic>
+            <characteristic name="Notes" typeId="d939-5084-e654-44c6">Forward Firing, Smoke</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="d322-f1e7-a8b0-9cd6" name="7.5cm Tank-hunter Team" hidden="false" typeId="7c70-b6af-9e5a-e7f6" typeName="Gun Unit">
+          <characteristics>
+            <characteristic name="Motivation" typeId="0954-f596-53ea-4ef7">3+</characteristic>
+            <characteristic name="Skill" typeId="a907-592d-ab2d-5ead">3+ / 4+ Assault</characteristic>
+            <characteristic name="Is Hit On" typeId="1f89-085b-464b-c60f">4+</characteristic>
+            <characteristic name="Save" typeId="ae14-5890-03de-a715">3+</characteristic>
+            <characteristic name="Tactical" typeId="3bad-79bd-27aa-4539">2&quot;/5cm</characteristic>
+            <characteristic name="Terrain Dash" typeId="a400-d543-6fb9-26d0">2&quot;/5cm</characteristic>
+            <characteristic name="Cross Country Dash" typeId="34ca-877a-8ffa-1006">4&quot;/10cm</characteristic>
+            <characteristic name="Road Dash" typeId="d283-e066-839c-fbd7">6&quot;/15cm</characteristic>
+            <characteristic name="Cross" typeId="3f9c-89f9-0b29-0585">3+</characteristic>
+            <characteristic name="Notes" typeId="28aa-390d-006a-1776"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="aa7d-b986-705e-64f2" name="Forward Firing" hidden="false" targetId="fa9d-68f6-57d9-dc5d" type="rule"/>
+        <infoLink id="ca86-a83d-b851-2d6c" name="Gun" hidden="false" targetId="139e-9d64-28a3-a3dd" type="rule"/>
+        <infoLink id="30ef-f4ef-4a20-e0ae" name="Gun Shield" hidden="false" targetId="2f2d-c5a9-ef7e-1b5e" type="rule"/>
+        <infoLink id="3333-9f7b-cc24-2013" name="Smoke Bombardment" hidden="false" targetId="5450-1722-5ad1-1d61" type="rule"/>
+        <infoLink id="b8a8-e933-1240-e0a1" name="Smoke" hidden="false" targetId="6f51-dbfe-55b0-a6d0" type="rule"/>
+      </infoLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="2490-419a-b1e4-d484" name="Unit Size" hidden="false" collective="false" import="true" defaultSelectionEntryId="30a7-a09f-3636-9a10">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3897-1a53-8b9f-31db" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d1ee-a08f-3343-ab8c" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="30a7-a09f-3636-9a10" name="2x 7.5cm mountain gun" hidden="false" collective="false" import="true" type="upgrade">
+              <costs>
+                <cost name="pts" typeId="995a-4d67-6920-bfe4" value="6.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="8d81-5f4f-0f08-8c9d" name="4x 7.5cm mountain gun" hidden="false" collective="false" import="true" type="upgrade">
+              <costs>
+                <cost name="pts" typeId="995a-4d67-6920-bfe4" value="12.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="9e3e-0802-adea-3947" name="Fallschirmjager Marder II Tank-hunter Platoon" hidden="false" collective="false" import="true" type="unit">
+      <profiles>
+        <profile id="1d56-150e-b9a2-3da6" name="Marder II (7.5cm) Tank-hunter" hidden="false" typeId="55ec-3ef5-ca51-e647" typeName="Tank Unit">
+          <characteristics>
+            <characteristic name="Motivation" typeId="046a-7f27-8072-dedb">3+ / 5+ Counterattack</characteristic>
+            <characteristic name="Skill" typeId="6334-745a-f712-a0aa">3+ / 5+ Assault</characteristic>
+            <characteristic name="Is Hit On" typeId="3931-565d-e382-fda5">4+</characteristic>
+            <characteristic name="Armour Front" typeId="b88a-3ca6-9b40-ff73">3</characteristic>
+            <characteristic name="Armour Side &amp; Rear" typeId="3712-51b3-aae3-94bd">1</characteristic>
+            <characteristic name="Armour Top" typeId="f551-1392-03e8-967d">0</characteristic>
+            <characteristic name="Tactical" typeId="ea9a-bf7d-68c5-e2d7">10&quot;/25cm</characteristic>
+            <characteristic name="Terrain Dash" typeId="f7f4-9e66-c9ed-034b">12&quot;/30cm</characteristic>
+            <characteristic name="Cross Country Dash" typeId="f73b-6fcf-b0d1-fde4">18&quot;/45cm</characteristic>
+            <characteristic name="Road Dash" typeId="b5b1-c829-470a-af62">20&quot;/50cm</characteristic>
+            <characteristic name="Cross" typeId="8be2-d5b6-ec4a-76d9">4+</characteristic>
+            <characteristic name="Notes" typeId="33d6-6375-9564-9985"/>
+          </characteristics>
+        </profile>
+        <profile id="9964-3eb0-5449-baae" name="Marder II (7.5cm)" hidden="false" typeId="33b6-a72a-2bd8-2565" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="c2e5-4990-8105-f793">32&quot;/80cm</characteristic>
+            <characteristic name="Halted ROF" typeId="7f6e-6f8f-5f15-6e9d">2</characteristic>
+            <characteristic name="Moving ROF" typeId="f78e-b583-b3a5-754a">1</characteristic>
+            <characteristic name="Anti-Tank" typeId="f57e-fa10-d0f9-e2dd">12</characteristic>
+            <characteristic name="Firepower" typeId="9cf3-a34f-60d9-1309">3+</characteristic>
+            <characteristic name="Notes" typeId="d939-5084-e654-44c6">Forward Firing</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="fe89-d9a8-361a-d663" name="Marder II (AA MG)" hidden="false" typeId="33b6-a72a-2bd8-2565" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="c2e5-4990-8105-f793">16&quot;/40cm</characteristic>
+            <characteristic name="Halted ROF" typeId="7f6e-6f8f-5f15-6e9d">3</characteristic>
+            <characteristic name="Moving ROF" typeId="f78e-b583-b3a5-754a">3</characteristic>
+            <characteristic name="Anti-Tank" typeId="f57e-fa10-d0f9-e2dd">2</characteristic>
+            <characteristic name="Firepower" typeId="9cf3-a34f-60d9-1309">6</characteristic>
+            <characteristic name="Notes" typeId="d939-5084-e654-44c6">Self-defense AA</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="80a6-197e-a81f-9a74" name="Stormtroopers" hidden="false" targetId="e2c1-5504-3684-b1fd" type="rule"/>
+        <infoLink id="6e0c-7e0f-0c00-33c5" name="Forward Firing" hidden="false" targetId="fa9d-68f6-57d9-dc5d" type="rule"/>
+        <infoLink id="f0d6-0839-cfd1-9734" name="Self-Defence AA" hidden="false" targetId="6c0b-8d39-70b6-9d1c" type="rule"/>
+      </infoLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="3652-b9e8-5d1b-a76e" name="Unit Size" hidden="false" collective="false" import="true" defaultSelectionEntryId="fe2e-b9ba-3663-2939">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="527e-c993-1f69-df23" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c5d5-2a46-7dd5-0edd" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="fe2e-b9ba-3663-2939" name="2x Marder II (7.5cm) Tank-hunter" hidden="false" collective="false" import="true" type="upgrade">
+              <costs>
+                <cost name="pts" typeId="995a-4d67-6920-bfe4" value="12.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="0fea-6555-d981-0bb7" name="3x Marder II (7.5cm)  Tank-hunter" hidden="false" collective="false" import="true" type="upgrade">
+              <costs>
+                <cost name="pts" typeId="995a-4d67-6920-bfe4" value="18.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="d119-bfbf-37a0-cd50" name="4x Marder II (7.5cm)  Tank-hunter" hidden="false" collective="false" import="true" type="upgrade">
+              <costs>
+                <cost name="pts" typeId="995a-4d67-6920-bfe4" value="23.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ab61-b1d3-2a76-30e8" name="Fallschirmjager Observation Post" hidden="false" collective="false" import="true" type="unit">
+      <profiles>
+        <profile id="6ca4-e441-d3aa-ca06" name="Fallschirmjager Observation Post" hidden="false" typeId="0917-e2f0-0c3e-b482" typeName="Infantry Unit">
+          <characteristics>
+            <characteristic name="Motivation" typeId="4aa0-1b18-70af-9474">3+ / 4+ Last Stand / 5+ Counterattack</characteristic>
+            <characteristic name="Skill" typeId="7258-881d-dc2d-e80b">3+</characteristic>
+            <characteristic name="Is Hit On" typeId="0641-f39f-6a33-7dcc">4+</characteristic>
+            <characteristic name="Save" typeId="4750-979d-b2bb-c536">3+</characteristic>
+            <characteristic name="Tactical" typeId="8027-bcf9-d953-3740">8&quot;/20cm</characteristic>
+            <characteristic name="Terrain Dash" typeId="b93a-5d61-9a77-50cc">8&quot;/20cm</characteristic>
+            <characteristic name="Cross Country Dash" typeId="4862-29d4-9ab9-76a0">12&quot;/30cm</characteristic>
+            <characteristic name="Road Dash" typeId="75e3-9f15-03c8-7f95">12&quot;/30cm</characteristic>
+            <characteristic name="Cross" typeId="2d03-7d6c-d869-db3f">AUTO</characteristic>
+            <characteristic name="Notes" typeId="173e-6395-d37b-31a2"></characteristic>
+          </characteristics>
+        </profile>
+        <profile id="46bf-45b5-bb63-934f" name="K98 Rifle team" hidden="false" typeId="33b6-a72a-2bd8-2565" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="c2e5-4990-8105-f793">16&quot;/40cm</characteristic>
+            <characteristic name="Halted ROF" typeId="7f6e-6f8f-5f15-6e9d">1</characteristic>
+            <characteristic name="Moving ROF" typeId="f78e-b583-b3a5-754a">1</characteristic>
+            <characteristic name="Anti-Tank" typeId="f57e-fa10-d0f9-e2dd">2</characteristic>
+            <characteristic name="Firepower" typeId="9cf3-a34f-60d9-1309">6</characteristic>
+            <characteristic name="Notes" typeId="d939-5084-e654-44c6">Slow Firing</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="b0fc-ce73-a6a8-de1e" name="Observer" hidden="false" targetId="8153-56ce-71c0-391b" type="rule"/>
+        <infoLink id="0c81-198a-ba21-f40a" name="Scout" hidden="false" targetId="967a-118e-dc01-7e0b" type="rule"/>
+        <infoLink id="500d-49c2-a5b5-117e" name="Stormtroopers" hidden="false" targetId="e2c1-5504-3684-b1fd" type="rule"/>
+        <infoLink id="6f5e-5cb3-f0e2-9a7f" name="Slow Firing" hidden="false" targetId="e215-d5bf-83ce-606a" type="rule"/>
+      </infoLinks>
+      <selectionEntries>
+        <selectionEntry id="7795-3a0d-6548-3c08" name="1x Observer K98 team" hidden="false" collective="false" import="true" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4338-e940-45df-f669" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="658e-091e-d856-f5db" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="995a-4d67-6920-bfe4" value="1.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntry>
+    <selectionEntry id="fc1b-0117-bfae-d9bf" name="Fallschirm Pioneer Platoon" hidden="false" collective="false" import="true" type="unit">
+      <infoLinks>
+        <infoLink id="5202-4e33-7c23-2b21" name="Fallschirmjager Platoon" hidden="false" targetId="a2e6-6e0b-2dbe-36e2" type="profile">
+          <modifiers>
+            <modifier type="set" field="name" value="Fallschirm Pioneer Platoon"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="3fd5-c979-3773-22fa" name="Pioneers" hidden="false" targetId="d976-1941-e942-421e" type="rule"/>
+        <infoLink id="d61b-502e-5236-02db" name="Stormtroopers" hidden="false" targetId="e2c1-5504-3684-b1fd" type="rule"/>
+        <infoLink id="5dde-aab2-c932-056c" name="MG42 &amp; K98 Rifle team" hidden="false" targetId="6eee-e478-0283-d72d" type="profile"/>
+        <infoLink id="d8f9-3229-10fc-31eb" name="Heavy Weapon" hidden="false" targetId="edf7-ad9c-029c-94fe" type="rule"/>
+        <infoLink id="eb49-d9ef-beef-a9e1" name="Flame-thrower" hidden="false" targetId="f8ec-4aba-faa0-f2d0" type="rule"/>
+        <infoLink id="fd6a-d15e-33c3-0b9f" name="Flame-thrower team" hidden="false" targetId="6715-bdc4-7de4-098e" type="profile"/>
+      </infoLinks>
+      <selectionEntries>
+        <selectionEntry id="fe88-b2a3-06ff-1252" name="0-1 2.8cm anti-tank rifle" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ecad-38e0-07b5-1d52" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="be2c-8716-4528-5da5" name="2.8cm anti-tank rifle" hidden="false" targetId="e39d-547d-6b1a-46e9" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="995a-4d67-6920-bfe4" value="2.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="8744-9c14-5a64-55a1" name="Unit Size" hidden="false" collective="false" import="true" defaultSelectionEntryId="ac87-b9ec-4676-e736">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ad8-131f-5b6e-c969" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bd59-874b-6b5c-e361" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="ac87-b9ec-4676-e736" name="5x MG42 &amp; K98 rifle teams, 2x Flame-thrower teams" hidden="false" collective="false" import="true" type="upgrade">
+              <costs>
+                <cost name="pts" typeId="995a-4d67-6920-bfe4" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="cee8-549d-617d-9b93" name="7x MG42 &amp; K98 rifle teams, 3x Flame-thrower teams" hidden="false" collective="false" import="true" type="upgrade">
+              <costs>
+                <cost name="pts" typeId="995a-4d67-6920-bfe4" value="15.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3278-296b-fd55-cec9" name="Fallschirmjager Company" hidden="false" collective="false" import="true" type="unit">
+      <selectionEntries>
+        <selectionEntry id="50e0-0e74-b68d-85db" name="Fallschirmjager Company HQ" hidden="false" collective="false" import="true" type="unit">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8551-3794-5ce6-d258" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9061-34c9-d8f1-77e3" type="min"/>
+          </constraints>
+          <profiles>
+            <profile id="3107-efa5-4620-082d" name="Fallschirmjager Company HQ" hidden="false" typeId="0917-e2f0-0c3e-b482" typeName="Infantry Unit">
+              <characteristics>
+                <characteristic name="Motivation" typeId="4aa0-1b18-70af-9474">3+</characteristic>
+                <characteristic name="Skill" typeId="7258-881d-dc2d-e80b">3+</characteristic>
+                <characteristic name="Is Hit On" typeId="0641-f39f-6a33-7dcc">4+</characteristic>
+                <characteristic name="Save" typeId="4750-979d-b2bb-c536">3+</characteristic>
+                <characteristic name="Tactical" typeId="8027-bcf9-d953-3740">8&quot;/20cm</characteristic>
+                <characteristic name="Terrain Dash" typeId="b93a-5d61-9a77-50cc">8&quot;/20cm</characteristic>
+                <characteristic name="Cross Country Dash" typeId="4862-29d4-9ab9-76a0">12&quot;/30cm</characteristic>
+                <characteristic name="Road Dash" typeId="75e3-9f15-03c8-7f95">12&quot;/30cm</characteristic>
+                <characteristic name="Cross" typeId="2d03-7d6c-d869-db3f">AUTO</characteristic>
+                <characteristic name="Notes" typeId="173e-6395-d37b-31a2"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="d6fe-e768-67ff-46ad" name="MP40 SMG Team" hidden="false" targetId="909b-8e52-a0b0-a080" type="profile"/>
+            <infoLink id="71dd-ada7-7a28-bbf4" name="Stormtroopers" hidden="false" targetId="e2c1-5504-3684-b1fd" type="rule"/>
+          </infoLinks>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="8e86-aa2a-d861-0add" name="Unit Size" hidden="false" collective="false" import="true" defaultSelectionEntryId="f146-af73-a010-eebb">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2b37-a2af-aa5c-cacb" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ca42-2022-27a3-f785" type="max"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="f146-af73-a010-eebb" name="2x MP40 SMG Team" hidden="false" collective="false" import="true" type="upgrade">
+                  <costs>
+                    <cost name="pts" typeId="995a-4d67-6920-bfe4" value="3.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="4571-302d-8006-d457" name="2x MP40 SMG Team, 1x 7.5cm Recoilless gun team" hidden="false" collective="false" import="true" type="upgrade">
+                  <infoLinks>
+                    <infoLink id="3b81-078f-e389-0bf8" name="7.5cm Recoilless Gun Team" hidden="false" targetId="a2e6-6e0b-2dbe-36e2" type="profile"/>
+                    <infoLink id="f952-4314-6c64-3f1f" name="Recoilless" hidden="false" targetId="104f-a2b8-aba6-fc6e" type="rule"/>
+                    <infoLink id="89ff-b4fd-892e-3f07" name="Heavy Weapon" hidden="false" targetId="edf7-ad9c-029c-94fe" type="rule"/>
+                    <infoLink id="1450-2982-4bad-f5ab" name="7.5cm Recoilless Gun" hidden="false" targetId="cbf8-861c-ba05-01b4" type="profile"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="995a-4d67-6920-bfe4" value="6.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="36f7-fa9a-60b9-0c9b" name="2x MP40 SMG Team, 2x 7.5cm Recoilless gun team" hidden="false" collective="false" import="true" type="upgrade">
+                  <infoLinks>
+                    <infoLink id="ce91-8217-0611-aec6" name="7.5cm Recoilless Gun Team" hidden="false" targetId="a2e6-6e0b-2dbe-36e2" type="profile"/>
+                    <infoLink id="de95-231e-b6fe-be81" name="Recoilless" hidden="false" targetId="104f-a2b8-aba6-fc6e" type="rule"/>
+                    <infoLink id="6143-e6be-4a9f-595d" name="Heavy Weapon" hidden="false" targetId="edf7-ad9c-029c-94fe" type="rule"/>
+                    <infoLink id="e965-8af7-02c7-66e5" name="7.5cm recoilless gun" hidden="false" targetId="cbf8-861c-ba05-01b4" type="profile"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="995a-4d67-6920-bfe4" value="9.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="6f4f-b5bc-2049-db47" name="Fallschirmjager Platoon" hidden="false" collective="false" import="true" targetId="6b07-e1ec-03dc-4f5d" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5850-e227-7901-3831" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9838-9638-58ef-fe38" type="min"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="c45c-9784-fbe4-4a6c" name="Fallschirmjager Platoon" hidden="false" collective="false" import="true" targetId="6b07-e1ec-03dc-4f5d" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2010-a43b-d241-7493" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9a9a-3baf-7966-abd3" type="min"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="1cf3-3f7f-df52-df8f" name="Fallschirmjager Platoon" hidden="false" collective="false" import="true" targetId="6b07-e1ec-03dc-4f5d" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f87e-8c8d-5009-9ebe" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="6f31-f3aa-726e-8305" name="Fallschirmjager 8cm Mortar Platoon" hidden="false" collective="false" import="true" targetId="9c25-71f5-93bb-3f5e" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="61e9-74da-59e6-65c3" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="77b5-6435-818d-4474" name="Fallschirmjager sMG42 Machine-gun Platoon" hidden="false" collective="false" import="true" targetId="7ed0-02e7-bbca-751d" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eb69-ffc9-f35e-00d7" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="bcc9-180a-70fc-ae93" name="Fallschirmjager 8cm Mortar Platoon" hidden="false" collective="false" import="true" targetId="9c25-71f5-93bb-3f5e" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3187-71be-c05c-0766" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f2cc-e643-a855-c888" name="2cm Anti-aircraft Platoon" hidden="false" collective="false" import="true" type="unit">
+      <profiles>
+        <profile id="e318-7cfe-ac9c-876a" name="2cm Anti-Aircraft Team" hidden="false" typeId="7c70-b6af-9e5a-e7f6" typeName="Gun Unit">
+          <characteristics>
+            <characteristic name="Motivation" typeId="0954-f596-53ea-4ef7">3+</characteristic>
+            <characteristic name="Skill" typeId="a907-592d-ab2d-5ead">3+ / 4+ Assault</characteristic>
+            <characteristic name="Is Hit On" typeId="1f89-085b-464b-c60f">4+</characteristic>
+            <characteristic name="Save" typeId="ae14-5890-03de-a715">3+</characteristic>
+            <characteristic name="Tactical" typeId="3bad-79bd-27aa-4539">4&quot;/10cm</characteristic>
+            <characteristic name="Terrain Dash" typeId="a400-d543-6fb9-26d0">4&quot;/10cm</characteristic>
+            <characteristic name="Cross Country Dash" typeId="34ca-877a-8ffa-1006">6&quot;/15cm</characteristic>
+            <characteristic name="Road Dash" typeId="d283-e066-839c-fbd7">8&quot;/20cm</characteristic>
+            <characteristic name="Cross" typeId="3f9c-89f9-0b29-0585">3+</characteristic>
+            <characteristic name="Notes" typeId="28aa-390d-006a-1776"/>
+          </characteristics>
+        </profile>
+        <profile id="f20c-c634-3ba4-b37b" name="2cm anti-aircraft gun" hidden="false" typeId="33b6-a72a-2bd8-2565" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="c2e5-4990-8105-f793">20&quot;/50cm</characteristic>
+            <characteristic name="Halted ROF" typeId="7f6e-6f8f-5f15-6e9d">3</characteristic>
+            <characteristic name="Moving ROF" typeId="f78e-b583-b3a5-754a">2</characteristic>
+            <characteristic name="Anti-Tank" typeId="f57e-fa10-d0f9-e2dd">5</characteristic>
+            <characteristic name="Firepower" typeId="9cf3-a34f-60d9-1309">5+</characteristic>
+            <characteristic name="Notes" typeId="d939-5084-e654-44c6">Dedicated AA</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="f08c-c38a-7551-1ae1" name="Dedicated AA" hidden="false" targetId="f4bc-db53-7a0d-0aeb" type="rule"/>
+        <infoLink id="91df-9694-0cab-93b3" name="Gun" hidden="false" targetId="139e-9d64-28a3-a3dd" type="rule"/>
+        <infoLink id="0036-95d6-e21b-002b" name="Gun Shield" hidden="false" targetId="2f2d-c5a9-ef7e-1b5e" type="rule"/>
+      </infoLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="ec0b-170d-3abc-3323" name="Unit Size" hidden="false" collective="false" import="true" defaultSelectionEntryId="088f-fa2f-3453-6f04">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6fd8-2ead-9285-a6af" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7994-41e8-9074-4fa1" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="088f-fa2f-3453-6f04" name="2x 2cm anti-aircraft gun" hidden="false" collective="false" import="true" type="upgrade">
+              <costs>
+                <cost name="pts" typeId="995a-4d67-6920-bfe4" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="2dac-7153-f197-75cf" name="3x 2cm anti-aircraft gun" hidden="false" collective="false" import="true" type="upgrade">
+              <costs>
+                <cost name="pts" typeId="995a-4d67-6920-bfe4" value="7.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="0b27-050c-d713-44dc" name="4x 2cm anti-aircraft gun" hidden="false" collective="false" import="true" type="upgrade">
+              <costs>
+                <cost name="pts" typeId="995a-4d67-6920-bfe4" value="10.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="c748-a6db-aa64-004a" name="JU 87 Stuka Dive Bomber Flight" hidden="false" collective="false" import="true" type="unit">
+      <profiles>
+        <profile id="3ea5-4d8c-107b-b8aa" name="JU 87 Stuka Dive Bomber Flight" hidden="false" typeId="d8ed-85c5-35d4-eb3c" typeName="Aircraft Unit">
+          <characteristics>
+            <characteristic name="Motivation" typeId="ec3b-729b-2af4-7bed">4+</characteristic>
+            <characteristic name="Skill" typeId="e506-9161-836a-5e2d">3+</characteristic>
+            <characteristic name="Is Hit On" typeId="9691-8132-58f7-5f86">5+</characteristic>
+            <characteristic name="Save" typeId="3a7a-29d5-008e-09f7">3+</characteristic>
+            <characteristic name="Tactical" typeId="8791-6355-ebcf-f430">UNLIMITED</characteristic>
+            <characteristic name="Terrain Dash" typeId="e6d2-8608-f213-ef1f"/>
+            <characteristic name="Cross Country Dash" typeId="037d-b1be-ca62-5c3e"/>
+            <characteristic name="Road Dash" typeId="207b-99f1-9a35-12d8"/>
+            <characteristic name="Cross" typeId="07b3-6909-7897-f282"/>
+            <characteristic name="Notes" typeId="8252-ebff-91e7-47ea">AUTO</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="aeba-0780-a3a7-2c8a" name="500kg bombs" hidden="false" typeId="33b6-a72a-2bd8-2565" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="c2e5-4990-8105-f793">6&quot;/15cm</characteristic>
+            <characteristic name="Halted ROF" typeId="7f6e-6f8f-5f15-6e9d">ARTILLERY</characteristic>
+            <characteristic name="Moving ROF" typeId="f78e-b583-b3a5-754a">4</characteristic>
+            <characteristic name="Anti-Tank" typeId="f57e-fa10-d0f9-e2dd">2+</characteristic>
+            <characteristic name="Firepower" typeId="9cf3-a34f-60d9-1309">Bombs</characteristic>
+            <characteristic name="Notes" typeId="d939-5084-e654-44c6"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="2ed0-3bf7-7438-f243" name="Bombs" hidden="false" targetId="78a2-7146-034e-a601" type="rule"/>
+      </infoLinks>
+      <selectionEntries>
+        <selectionEntry id="0cbb-e985-38c9-77ce" name="2x Ju 87 Stuka" hidden="false" collective="false" import="true" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0b0e-c03a-fd0c-479f" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1cdc-6831-c0ef-e9d5" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="995a-4d67-6920-bfe4" value="9.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntry>
+    <selectionEntry id="6b07-e1ec-03dc-4f5d" name="Fallschirmjager Platoon" hidden="false" collective="false" import="true" type="unit">
+      <infoLinks>
+        <infoLink id="0286-611c-e789-a91e" name="Fallschirmjager Platoon" hidden="false" targetId="a2e6-6e0b-2dbe-36e2" type="profile"/>
+        <infoLink id="acab-82a0-fd4f-0aa3" name="Stormtroopers" hidden="false" targetId="e2c1-5504-3684-b1fd" type="rule"/>
+        <infoLink id="8884-aa89-f7e1-a2b7" name="MG42 &amp; K98 Rifle team" hidden="false" targetId="6eee-e478-0283-d72d" type="profile"/>
+      </infoLinks>
+      <selectionEntries>
+        <selectionEntry id="bf7f-f6df-0820-b41e" name="0-2 sMG42 HMGs" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6299-b4d7-12fb-cd92" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="89d8-fe0a-9637-69e6" name="sMG42 HMG" hidden="false" targetId="574d-94e3-6123-71c4" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="995a-4d67-6920-bfe4" value="2.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="ebae-1a94-a605-d44b" name="0-1 2.8cm anti-tank rifle" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="787c-a8e9-aa2c-7185" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="a366-31c6-87ad-0af0" name="Heavy Weapon" hidden="false" targetId="edf7-ad9c-029c-94fe" type="rule"/>
+            <infoLink id="b384-6a48-eaa2-e849" name="No HE" hidden="false" targetId="b000-d0f1-08fd-0d43" type="rule"/>
+            <infoLink id="9324-59fd-3785-ae9a" name="2.8cm anti-tank rifle" hidden="false" targetId="e39d-547d-6b1a-46e9" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="995a-4d67-6920-bfe4" value="2.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="5c9d-c235-bbe1-286b" name="Unit Size" hidden="false" collective="false" import="true" defaultSelectionEntryId="e669-3706-c610-b8b0">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d10e-7f15-73dc-afe7" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="db00-de0c-dd3f-5dc3" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="ba7a-a97f-2e1d-1a4a" name="10x MG42 &amp; K98 Rifle teams " hidden="false" collective="false" import="true" type="upgrade">
+              <costs>
+                <cost name="pts" typeId="995a-4d67-6920-bfe4" value="13.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="e669-3706-c610-b8b0" name="7x MG42 &amp; K98 Rifle teams " hidden="false" collective="false" import="true" type="upgrade">
+              <costs>
+                <cost name="pts" typeId="995a-4d67-6920-bfe4" value="9.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="9c25-71f5-93bb-3f5e" name="Fallschirmjager 8cm Mortar Platoon" hidden="false" collective="false" import="true" type="unit">
+      <profiles>
+        <profile id="1909-3739-2df6-d1c1" name="8cm Mortar Team" hidden="false" typeId="0917-e2f0-0c3e-b482" typeName="Infantry Unit">
+          <characteristics>
+            <characteristic name="Motivation" typeId="4aa0-1b18-70af-9474">3+</characteristic>
+            <characteristic name="Skill" typeId="7258-881d-dc2d-e80b">3+ / 4+ Assault</characteristic>
+            <characteristic name="Is Hit On" typeId="0641-f39f-6a33-7dcc">4+</characteristic>
+            <characteristic name="Save" typeId="4750-979d-b2bb-c536">3+</characteristic>
+            <characteristic name="Tactical" typeId="8027-bcf9-d953-3740">4&quot;/10cm</characteristic>
+            <characteristic name="Terrain Dash" typeId="b93a-5d61-9a77-50cc">4&quot;/10cm</characteristic>
+            <characteristic name="Cross Country Dash" typeId="4862-29d4-9ab9-76a0">6&quot;/20cm</characteristic>
+            <characteristic name="Road Dash" typeId="75e3-9f15-03c8-7f95">6&quot;/20cm</characteristic>
+            <characteristic name="Cross" typeId="2d03-7d6c-d869-db3f">AUTO</characteristic>
+            <characteristic name="Notes" typeId="173e-6395-d37b-31a2"/>
+          </characteristics>
+        </profile>
+        <profile id="43ba-d37d-8e18-89f7" name="8cm Stummel Mortar" hidden="false" typeId="33b6-a72a-2bd8-2565" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="c2e5-4990-8105-f793">32&quot;/80cm</characteristic>
+            <characteristic name="Halted ROF" typeId="7f6e-6f8f-5f15-6e9d">ARTILLERY</characteristic>
+            <characteristic name="Moving ROF" typeId="f78e-b583-b3a5-754a"/>
+            <characteristic name="Anti-Tank" typeId="f57e-fa10-d0f9-e2dd">1</characteristic>
+            <characteristic name="Firepower" typeId="9cf3-a34f-60d9-1309">4+</characteristic>
+            <characteristic name="Notes" typeId="d939-5084-e654-44c6">Smoke Bombardment</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="392a-b56f-1519-e55e" name="Smoke Bombardment" hidden="false" targetId="5450-1722-5ad1-1d61" type="rule"/>
+        <infoLink id="b62a-da66-d778-355c" name="Heavy Weapon" hidden="false" targetId="edf7-ad9c-029c-94fe" type="rule"/>
+        <infoLink id="d609-3ce2-1938-8c13" name="Stormtroopers" hidden="false" targetId="e2c1-5504-3684-b1fd" type="rule"/>
+      </infoLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="40f2-5f17-3c47-0f42" name="Unit Size" hidden="false" collective="false" import="true" defaultSelectionEntryId="4140-8beb-e8ff-826a">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f173-b8c9-23a8-d128" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="10e9-5ce5-070e-e60e" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="4140-8beb-e8ff-826a" name="8cm Stummel Mortar Team" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9536-eb45-dca5-f2b6" type="min"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="995a-4d67-6920-bfe4" value="2.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7ed0-02e7-bbca-751d" name="Fallschirmjager sMG42 Machine-gun Platoon" hidden="false" collective="false" import="true" type="unit">
+      <profiles>
+        <profile id="44f4-3704-9490-3c24" name="sMG42 Machine-gun team" hidden="false" typeId="0917-e2f0-0c3e-b482" typeName="Infantry Unit">
+          <characteristics>
+            <characteristic name="Motivation" typeId="4aa0-1b18-70af-9474">3+</characteristic>
+            <characteristic name="Skill" typeId="7258-881d-dc2d-e80b">3+ / 4+ Assault</characteristic>
+            <characteristic name="Is Hit On" typeId="0641-f39f-6a33-7dcc">4+</characteristic>
+            <characteristic name="Save" typeId="4750-979d-b2bb-c536">3+</characteristic>
+            <characteristic name="Tactical" typeId="8027-bcf9-d953-3740">8&quot;/20cm</characteristic>
+            <characteristic name="Terrain Dash" typeId="b93a-5d61-9a77-50cc">8&quot;/20cm</characteristic>
+            <characteristic name="Cross Country Dash" typeId="4862-29d4-9ab9-76a0">12&quot;/30cm</characteristic>
+            <characteristic name="Road Dash" typeId="75e3-9f15-03c8-7f95">12&quot;/30cm</characteristic>
+            <characteristic name="Cross" typeId="2d03-7d6c-d869-db3f">AUTO</characteristic>
+            <characteristic name="Notes" typeId="173e-6395-d37b-31a2"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="c184-6c44-778f-0ca7" name="sMG42 HMG" hidden="false" targetId="574d-94e3-6123-71c4" type="profile"/>
+        <infoLink id="534a-b1ad-34f2-ce99" name="Heavy Weapon" hidden="false" targetId="edf7-ad9c-029c-94fe" type="rule"/>
+        <infoLink id="ac30-a62a-25cc-d91c" name="Stormtroopers" hidden="false" targetId="e2c1-5504-3684-b1fd" type="rule"/>
+      </infoLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="d7ab-49f8-fb70-a907" name="Unit Size" hidden="false" collective="false" import="true" defaultSelectionEntryId="372b-8b54-fe41-7e91">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="062f-666f-88ac-b5ae" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4b71-b87e-720c-2a79" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="372b-8b54-fe41-7e91" name="2x sMG42 HMGs" hidden="false" collective="false" import="true" type="upgrade">
+              <costs>
+                <cost name="pts" typeId="995a-4d67-6920-bfe4" value="3.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="e3c9-6fa3-b4b5-2c5c" name="4x sMG42 HMGs" hidden="false" collective="false" import="true" type="upgrade">
+              <costs>
+                <cost name="pts" typeId="995a-4d67-6920-bfe4" value="6.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntry>
+    <selectionEntry id="3ab5-6215-3c8c-7495" name="Fallschirmjager 7.5cm Artillery Battery" hidden="false" collective="false" import="true" type="unit">
+      <profiles>
+        <profile id="3ecc-4a82-5010-e9c9" name="7.5cm Artillery Team" hidden="false" typeId="7c70-b6af-9e5a-e7f6" typeName="Gun Unit">
+          <characteristics>
+            <characteristic name="Motivation" typeId="0954-f596-53ea-4ef7">3+</characteristic>
+            <characteristic name="Skill" typeId="a907-592d-ab2d-5ead">3+ / 4+ Assault</characteristic>
+            <characteristic name="Is Hit On" typeId="1f89-085b-464b-c60f">4+</characteristic>
+            <characteristic name="Save" typeId="ae14-5890-03de-a715">4+</characteristic>
+            <characteristic name="Tactical" typeId="3bad-79bd-27aa-4539">4&quot;/10cm</characteristic>
+            <characteristic name="Terrain Dash" typeId="a400-d543-6fb9-26d0">4&quot;/10cm</characteristic>
+            <characteristic name="Cross Country Dash" typeId="34ca-877a-8ffa-1006">6&quot;/15cm</characteristic>
+            <characteristic name="Road Dash" typeId="d283-e066-839c-fbd7">8&quot;/20cm</characteristic>
+            <characteristic name="Cross" typeId="3f9c-89f9-0b29-0585">3+</characteristic>
+            <characteristic name="Notes" typeId="28aa-390d-006a-1776"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="9690-2bb2-3ab8-2aad" name="Forward Firing" hidden="false" targetId="fa9d-68f6-57d9-dc5d" type="rule"/>
+        <infoLink id="8833-2fe5-ff03-d21e" name="Gun Shield" hidden="false" targetId="2f2d-c5a9-ef7e-1b5e" type="rule"/>
+        <infoLink id="c8cb-801f-3332-fdde" name="Gun" hidden="false" targetId="139e-9d64-28a3-a3dd" type="rule"/>
+      </infoLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="02ec-8870-9d11-4846" name="Unit Size" hidden="false" collective="false" import="true" defaultSelectionEntryId="4f7c-ed09-6b25-b979">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1626-cd0c-507f-b60f" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8182-8216-0d25-4cdb" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="4285-c241-0ea1-8e16" name="3x 7.5cm gun" hidden="false" collective="false" import="true" type="upgrade">
+              <costs>
+                <cost name="pts" typeId="995a-4d67-6920-bfe4" value="22.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="4f7c-ed09-6b25-b979" name="2x 7.5cm gun" hidden="false" collective="false" import="true" type="upgrade">
+              <costs>
+                <cost name="pts" typeId="995a-4d67-6920-bfe4" value="15.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="f162-0745-e66f-c8ba" name="4x 7.5cm gun" hidden="false" collective="false" import="true" type="upgrade">
+              <costs>
+                <cost name="pts" typeId="995a-4d67-6920-bfe4" value="29.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
+      </costs>
+    </selectionEntry>
+  </sharedSelectionEntries>
+  <sharedRules>
+    <rule id="e2c1-5504-3684-b1fd" name="Stormtroopers" hidden="false">
+      <description>A unit may attempt a second Movement Order after succeeding in its first Movement Order. The second Movement Order must be different from the first.</description>
+    </rule>
+    <rule id="104f-a2b8-aba6-fc6e" name="Recoilless" hidden="false">
+      <description>No idea what this does yet.</description>
+    </rule>
+    <rule id="d976-1941-e942-421e" name="Pioneers" hidden="false">
+      <description>No idea what this does yet.</description>
+    </rule>
+  </sharedRules>
+  <sharedProfiles>
+    <profile id="a2e6-6e0b-2dbe-36e2" name="Fallschirmjager Platoon" hidden="false" typeId="0917-e2f0-0c3e-b482" typeName="Infantry Unit">
+      <characteristics>
+        <characteristic name="Motivation" typeId="4aa0-1b18-70af-9474">3+</characteristic>
+        <characteristic name="Skill" typeId="7258-881d-dc2d-e80b">3+</characteristic>
+        <characteristic name="Is Hit On" typeId="0641-f39f-6a33-7dcc">4+</characteristic>
+        <characteristic name="Save" typeId="4750-979d-b2bb-c536">3+</characteristic>
+        <characteristic name="Tactical" typeId="8027-bcf9-d953-3740">8&quot;/20cm</characteristic>
+        <characteristic name="Terrain Dash" typeId="b93a-5d61-9a77-50cc">8&quot;/20cm</characteristic>
+        <characteristic name="Cross Country Dash" typeId="4862-29d4-9ab9-76a0">12&quot;/30cm</characteristic>
+        <characteristic name="Road Dash" typeId="75e3-9f15-03c8-7f95">12&quot;/30cm</characteristic>
+        <characteristic name="Cross" typeId="2d03-7d6c-d869-db3f">AUTO</characteristic>
+        <characteristic name="Notes" typeId="173e-6395-d37b-31a2"></characteristic>
+      </characteristics>
+    </profile>
+    <profile id="cbf8-861c-ba05-01b4" name="7.5cm Recoilless Gun" hidden="false" typeId="33b6-a72a-2bd8-2565" typeName="Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="c2e5-4990-8105-f793">16&quot;/40cm</characteristic>
+        <characteristic name="Halted ROF" typeId="7f6e-6f8f-5f15-6e9d">2</characteristic>
+        <characteristic name="Moving ROF" typeId="f78e-b583-b3a5-754a">1</characteristic>
+        <characteristic name="Anti-Tank" typeId="f57e-fa10-d0f9-e2dd">9</characteristic>
+        <characteristic name="Firepower" typeId="9cf3-a34f-60d9-1309">3+</characteristic>
+        <characteristic name="Notes" typeId="d939-5084-e654-44c6">Forward Firing</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="909b-8e52-a0b0-a080" name="MP40 SMG Team" hidden="false" typeId="33b6-a72a-2bd8-2565" typeName="Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="c2e5-4990-8105-f793">4&quot;/10cm</characteristic>
+        <characteristic name="Halted ROF" typeId="7f6e-6f8f-5f15-6e9d">3</characteristic>
+        <characteristic name="Moving ROF" typeId="f78e-b583-b3a5-754a">3</characteristic>
+        <characteristic name="Anti-Tank" typeId="f57e-fa10-d0f9-e2dd">1</characteristic>
+        <characteristic name="Firepower" typeId="9cf3-a34f-60d9-1309">6</characteristic>
+        <characteristic name="Notes" typeId="d939-5084-e654-44c6">Pinned ROF 1</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="3dc0-c129-215e-0f42" name="7.5cm Recoilless Gun team" hidden="false" typeId="0917-e2f0-0c3e-b482" typeName="Infantry Unit">
+      <characteristics>
+        <characteristic name="Motivation" typeId="4aa0-1b18-70af-9474">3+</characteristic>
+        <characteristic name="Skill" typeId="7258-881d-dc2d-e80b">3+ / 4+ Assault</characteristic>
+        <characteristic name="Is Hit On" typeId="0641-f39f-6a33-7dcc">4+</characteristic>
+        <characteristic name="Save" typeId="4750-979d-b2bb-c536">3+</characteristic>
+        <characteristic name="Tactical" typeId="8027-bcf9-d953-3740">8&quot;/20cm</characteristic>
+        <characteristic name="Terrain Dash" typeId="b93a-5d61-9a77-50cc">8&quot;/20cm</characteristic>
+        <characteristic name="Cross Country Dash" typeId="4862-29d4-9ab9-76a0">12&quot;/30cm</characteristic>
+        <characteristic name="Road Dash" typeId="75e3-9f15-03c8-7f95">12&quot;/30cm</characteristic>
+        <characteristic name="Cross" typeId="2d03-7d6c-d869-db3f">AUTO</characteristic>
+        <characteristic name="Notes" typeId="173e-6395-d37b-31a2"></characteristic>
+      </characteristics>
+    </profile>
+    <profile id="6eee-e478-0283-d72d" name="MG42 &amp; K98 Rifle team" hidden="false" typeId="33b6-a72a-2bd8-2565" typeName="Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="c2e5-4990-8105-f793">16&quot;/40cm</characteristic>
+        <characteristic name="Halted ROF" typeId="7f6e-6f8f-5f15-6e9d">2</characteristic>
+        <characteristic name="Moving ROF" typeId="f78e-b583-b3a5-754a">1</characteristic>
+        <characteristic name="Anti-Tank" typeId="f57e-fa10-d0f9-e2dd">2</characteristic>
+        <characteristic name="Firepower" typeId="9cf3-a34f-60d9-1309">6</characteristic>
+        <characteristic name="Notes" typeId="d939-5084-e654-44c6"/>
+      </characteristics>
+    </profile>
+    <profile id="574d-94e3-6123-71c4" name="sMG42 HMG" hidden="false" typeId="33b6-a72a-2bd8-2565" typeName="Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="c2e5-4990-8105-f793">24&quot;/60cm</characteristic>
+        <characteristic name="Halted ROF" typeId="7f6e-6f8f-5f15-6e9d">6</characteristic>
+        <characteristic name="Moving ROF" typeId="f78e-b583-b3a5-754a">2</characteristic>
+        <characteristic name="Anti-Tank" typeId="f57e-fa10-d0f9-e2dd">2</characteristic>
+        <characteristic name="Firepower" typeId="9cf3-a34f-60d9-1309">6</characteristic>
+        <characteristic name="Notes" typeId="d939-5084-e654-44c6">Assault 4+, Heavy Weapon</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="e39d-547d-6b1a-46e9" name="2.8cm anti-tank rifle" hidden="false" typeId="33b6-a72a-2bd8-2565" typeName="Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="c2e5-4990-8105-f793">20&quot;/50cm</characteristic>
+        <characteristic name="Halted ROF" typeId="7f6e-6f8f-5f15-6e9d">2</characteristic>
+        <characteristic name="Moving ROF" typeId="f78e-b583-b3a5-754a">1</characteristic>
+        <characteristic name="Anti-Tank" typeId="f57e-fa10-d0f9-e2dd">7</characteristic>
+        <characteristic name="Firepower" typeId="9cf3-a34f-60d9-1309">5+</characteristic>
+        <characteristic name="Notes" typeId="d939-5084-e654-44c6">Assault 4+, Heavy Weapon, No HE</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="6715-bdc4-7de4-098e" name="Flame-thrower team" hidden="false" typeId="33b6-a72a-2bd8-2565" typeName="Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="c2e5-4990-8105-f793">6&quot;/15cm</characteristic>
+        <characteristic name="Halted ROF" typeId="7f6e-6f8f-5f15-6e9d">2</characteristic>
+        <characteristic name="Moving ROF" typeId="f78e-b583-b3a5-754a">2</characteristic>
+        <characteristic name="Anti-Tank" typeId="f57e-fa10-d0f9-e2dd">2</characteristic>
+        <characteristic name="Firepower" typeId="9cf3-a34f-60d9-1309">AUTO</characteristic>
+        <characteristic name="Notes" typeId="d939-5084-e654-44c6">Assault 4+, Flame-thrower, Heavy Weapon, Pinned ROF 1</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="b1d4-463e-6275-932a" name="3.7cm gun" hidden="false" typeId="33b6-a72a-2bd8-2565" typeName="Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="c2e5-4990-8105-f793">24&quot;/60cm</characteristic>
+        <characteristic name="Halted ROF" typeId="7f6e-6f8f-5f15-6e9d">2</characteristic>
+        <characteristic name="Moving ROF" typeId="f78e-b583-b3a5-754a">1</characteristic>
+        <characteristic name="Anti-Tank" typeId="f57e-fa10-d0f9-e2dd">6</characteristic>
+        <characteristic name="Firepower" typeId="9cf3-a34f-60d9-1309">4+</characteristic>
+        <characteristic name="Notes" typeId="d939-5084-e654-44c6">Forward Firing</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="2db5-7b6e-328f-79b2" name="3.7cm (firing Stielgranate)" hidden="false" typeId="33b6-a72a-2bd8-2565" typeName="Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="c2e5-4990-8105-f793">10&quot;/25cm</characteristic>
+        <characteristic name="Halted ROF" typeId="7f6e-6f8f-5f15-6e9d">1</characteristic>
+        <characteristic name="Moving ROF" typeId="f78e-b583-b3a5-754a">1</characteristic>
+        <characteristic name="Anti-Tank" typeId="f57e-fa10-d0f9-e2dd">12</characteristic>
+        <characteristic name="Firepower" typeId="9cf3-a34f-60d9-1309">5+</characteristic>
+        <characteristic name="Notes" typeId="d939-5084-e654-44c6">Forward Firing, Slow Firing</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="df40-6714-a072-4b05" name="5cm gun" hidden="false" typeId="33b6-a72a-2bd8-2565" typeName="Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="c2e5-4990-8105-f793">28&quot;/70cm</characteristic>
+        <characteristic name="Halted ROF" typeId="7f6e-6f8f-5f15-6e9d">2</characteristic>
+        <characteristic name="Moving ROF" typeId="f78e-b583-b3a5-754a">1</characteristic>
+        <characteristic name="Anti-Tank" typeId="f57e-fa10-d0f9-e2dd">9</characteristic>
+        <characteristic name="Firepower" typeId="9cf3-a34f-60d9-1309">4+</characteristic>
+        <characteristic name="Notes" typeId="d939-5084-e654-44c6">Forward Firing</characteristic>
+      </characteristics>
+    </profile>
+  </sharedProfiles>
+</catalogue>


### PR DESCRIPTION
In updating the Afrika Korps catalog to be more user and maintainer friendly, I've done a complete overhaul from the ground up in accordance with how other systems handle their data.

In this way, with a simple set of guidelines, we can move forward and update the rest of the data if this format is found to be conducive to co-operation and quality assurance.

I also added the Fallschirmjager splatbook "Death from Above" that can be added to any Mid-War German book; right now, it's only implemented in Afrika Korps since I don't see Ghost Panzers or Iron Cross in Battlescribe right now.

There's still some data entry work left for Afrika Korps (Command Cards, some abilities, some units I didn't have the cards for, etc), but it's mostly done at this point.

Oh, I did see "Dynamic Points 2024" recently; that hasn't been implemented, right? I can do that afterwards if y'all like this format.

To be more clear about general changes:

1. Root Entries should only be references, not Selection Entries; I moved all SEs to the Shared Selection Entry area rather than the Root Selection Entry area.
2. Categories go on REs, not SEs; this means maintainers will always Categorize REs in the RSEA rather than needing to swap them around inside the SSEA.
3. Rather than replicating duplicate SEs within Companies, we can create a single SE and reference it multiple times. To get around the common "Max 1 of X" problem, you can just turn off "Shared" in the Constraint for a given SE Link. Please see almost all of my Companies for examples.
4. Formation Support should only appear once a relevant Formation has been selected (if my interpretation of "any formations *in the Force*" is correct), so I've hidden their RSEs until their Formation is selected.