### PR TITLE
Add Flames of War force codes (LG/LU/LB/LS…) to unit names

### DIFF
--- a/LW - Bagration_German.cat
+++ b/LW - Bagration_German.cat
@@ -754,7 +754,7 @@ Support the creators, buy the book!</readme>
         <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="6e68-6062-01ef-35e9" name="7.5cm Tank-Hunter Platoon" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="6e68-6062-01ef-35e9" name="7.5cm Tank-Hunter Platoon (LG131)" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="f2c7-98e5-9b5e-9b7d" name="7.5cm anti-tank gun" hidden="false" typeId="7c70-b6af-9e5a-e7f6" typeName="Gun Unit">
           <modifiers>
@@ -941,7 +941,7 @@ Support the creators, buy the book!</readme>
         <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="b508-4010-cdb6-9241" name="Armoured 8cm Mortar Section" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="b508-4010-cdb6-9241" name="Armoured 8cm Mortar Section (LG115)" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="cf69-732e-270a-efd8" name="Sd Kfz 251 (8cm)" hidden="false" typeId="55ec-3ef5-ca51-e647" typeName="Tank Unit">
           <modifiers>
@@ -1210,7 +1210,7 @@ Support the creators, buy the book!</readme>
         <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="d5f4-7aa4-e8d3-b597" name="Sd Kfz 10/4 Light AA Platoon" publicationId="10a4-8008-66c3-952e" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="d5f4-7aa4-e8d3-b597" name="Sd Kfz 10/4 Light AA Platoon (LG142)" publicationId="10a4-8008-66c3-952e" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="8db5-52a2-f407-ff14" name="Sd Kfz 10/4 (2cm) - 20th" hidden="true" typeId="7cf5-5c36-14cc-3c0d" typeName="Unarmoured Tank Unit">
           <modifiers>
@@ -1293,7 +1293,7 @@ Support the creators, buy the book!</readme>
         <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="d4d9-0de5-ee7f-d86c" name="15cm Gun Platoon" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="d4d9-0de5-ee7f-d86c" name="15cm Gun Platoon (LG127)" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="f601-44ac-c54a-8cab" name="15cm infantry gun" hidden="false" typeId="7c70-b6af-9e5a-e7f6" typeName="Gun Unit">
           <modifiers>
@@ -1366,7 +1366,7 @@ Support the creators, buy the book!</readme>
         <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="a9a5-5ae3-c750-9b07" name="Grille 15cm Gun Platoon" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="a9a5-5ae3-c750-9b07" name="Grille 15cm Gun Platoon (LG118)" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="752e-97dd-5a28-d532" name="Grille (15cm)" hidden="false" typeId="55ec-3ef5-ca51-e647" typeName="Tank Unit">
           <modifiers>
@@ -2052,7 +2052,7 @@ Support the creators, buy the book!</readme>
         <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="6339-7749-144e-e9d0" name="12cm Mortar Platoon" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="6339-7749-144e-e9d0" name="12cm Mortar Platoon (LG172)" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="580a-2203-ae4b-eee5" name="12cm mortar" hidden="false" typeId="7c70-b6af-9e5a-e7f6" typeName="Gun Unit">
           <modifiers>
@@ -2270,7 +2270,7 @@ Support the creators, buy the book!</readme>
         <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="ad83-f9b3-bd18-bb69" name="8cm Mortar Platoon" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="ad83-f9b3-bd18-bb69" name="8cm Mortar Platoon (LG125)" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="a9b8-cd0d-f750-2fdc" name="8cm mortar" hidden="false" typeId="0917-e2f0-0c3e-b482" typeName="Infantry Unit">
           <modifiers>
@@ -2538,7 +2538,7 @@ Support the creators, buy the book!</readme>
         <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="8245-424c-8a3f-aef3" name="Reconnaissance 8cm Mortar Section" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="8245-424c-8a3f-aef3" name="Reconnaissance 8cm Mortar Section (LG176)" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="9e12-57d2-e367-6c67" name="Sd Kfz 250 (8cm)" hidden="false" typeId="33b6-a72a-2bd8-2565" typeName="Weapon">
           <characteristics>
@@ -2600,7 +2600,7 @@ Support the creators, buy the book!</readme>
         <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="f5ae-9a95-a66e-ac18" name="Sd Kfc 234 (7.5cm) Gun Platoon" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="f5ae-9a95-a66e-ac18" name="Sd Kfc 234 (7.5cm) Gun Platoon (LG188)" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="67a8-82b8-5b7c-f705" name="Sd Kfc 234 (7.5cm)" hidden="false" typeId="55ec-3ef5-ca51-e647" typeName="Tank Unit">
           <characteristics>
@@ -2778,7 +2778,7 @@ Support the creators, buy the book!</readme>
         <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="e412-f7dd-0ee3-90ba" name="Sd Kfz 250 Scout Troop" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="e412-f7dd-0ee3-90ba" name="Sd Kfz 250 Scout Troop (LG179)" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="2978-dc76-711e-b1c7" name="Sd Kfz 250/9 (2cm)" hidden="false" typeId="33b6-a72a-2bd8-2565" typeName="Weapon">
           <characteristics>
@@ -2897,7 +2897,7 @@ Support the creators, buy the book!</readme>
         <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="7b39-c0fb-5da4-59a3" name="Jagdpanzer IV Tank-Hunter Platoon" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="7b39-c0fb-5da4-59a3" name="Jagdpanzer IV Tank-Hunter Platoon (LG181)" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="e10b-8718-10c9-6a4e" name="Jagdpanzer IV (7.5cm)" hidden="false" typeId="55ec-3ef5-ca51-e647" typeName="Tank Unit">
           <characteristics>
@@ -2974,7 +2974,7 @@ Support the creators, buy the book!</readme>
         <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="9adb-03e6-89f6-0b24" name="Sd Kfz 7/1 Quad AA Platoon" publicationId="b8e5-51cf-456c-eafb" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="9adb-03e6-89f6-0b24" name="Sd Kfz 7/1 Quad AA Platoon (LG143)" publicationId="b8e5-51cf-456c-eafb" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="f352-01c3-0dbf-d740" name="Sd Kfz 7/1 (2cm quad)" hidden="false" typeId="7cf5-5c36-14cc-3c0d" typeName="Unarmoured Tank Unit">
           <characteristics>
@@ -3032,7 +3032,7 @@ Support the creators, buy the book!</readme>
         <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="fcb2-85d8-074a-978f" name="10.5cm Artillery Battery" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="fcb2-85d8-074a-978f" name="10.5cm Artillery Battery (LG136)" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="e4a2-e91d-ac1c-b562" name="10.5cm howitzer" hidden="false" typeId="7c70-b6af-9e5a-e7f6" typeName="Gun Unit">
           <characteristics>
@@ -3109,7 +3109,7 @@ Support the creators, buy the book!</readme>
         <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="b6de-c5a6-d9a6-399a" name="Hummel Artillery Battery" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="b6de-c5a6-d9a6-399a" name="Hummel Artillery Battery (LG135)" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="8d97-f31f-4609-cc95" name="Hummel (15cm)" hidden="false" typeId="55ec-3ef5-ca51-e647" typeName="Tank Unit">
           <characteristics>
@@ -3191,7 +3191,7 @@ Support the creators, buy the book!</readme>
         <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="17d1-62a8-d8f2-0eeb" name="Wespe Artillery Battery" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="17d1-62a8-d8f2-0eeb" name="Wespe Artillery Battery (LG134)" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="048e-ab3f-15b6-38f5" name="Wespe (10.5cm)" hidden="false" typeId="55ec-3ef5-ca51-e647" typeName="Tank Unit">
           <characteristics>
@@ -3276,7 +3276,7 @@ Support the creators, buy the book!</readme>
         <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="dace-3b54-229e-60b2" name="15cm Nebelwerfer Battery" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="dace-3b54-229e-60b2" name="15cm Nebelwerfer Battery (LG137)" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="a5fa-01e1-7387-1cd6" name="15cm Nebelwerfer" hidden="false" typeId="7c70-b6af-9e5a-e7f6" typeName="Gun Unit">
           <characteristics>
@@ -3396,7 +3396,7 @@ Support the creators, buy the book!</readme>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="133e-819f-7971-02d6" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="c6c3-7eb1-021c-ea92" name="5cm Tank-Hunter Platoon" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="c6c3-7eb1-021c-ea92" name="5cm Tank-Hunter Platoon (LG124)" hidden="false" collective="false" import="true" type="upgrade">
               <profiles>
                 <profile id="9f19-e620-92e3-1dcd" name="5cm gun" hidden="false" typeId="7c70-b6af-9e5a-e7f6" typeName="Gun Unit">
                   <characteristics>
@@ -3898,7 +3898,7 @@ Unit hits on 2+ &amp; Counterattacks 3+</description>
         <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="2203-1bbb-e22b-449f" name="Panther Tank Platoon" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="2203-1bbb-e22b-449f" name="Panther Tank Platoon (LG104)" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="0139-9402-fd68-7bce" name="Panther (7.5cm) - 20th" hidden="true" typeId="55ec-3ef5-ca51-e647" typeName="Tank Unit">
           <modifiers>
@@ -3970,7 +3970,7 @@ Unit hits on 2+ &amp; Counterattacks 3+</description>
         <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="1651-2e60-9d01-0bc6" name="8.8cm Heavy AA Platoon" publicationId="b8e5-51cf-456c-eafb" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="1651-2e60-9d01-0bc6" name="8.8cm Heavy AA Platoon (LG144)" publicationId="b8e5-51cf-456c-eafb" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="2794-9430-1c47-a698" name="8.8cm AA gun" hidden="false" typeId="7c70-b6af-9e5a-e7f6" typeName="Gun Unit">
           <characteristics>
@@ -4194,7 +4194,7 @@ Unit hits on 2+ &amp; Counterattacks 3+</description>
         <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="47ee-b8bc-0561-5ab9" name="Tiger Tank Platoon" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="47ee-b8bc-0561-5ab9" name="Tiger Tank Platoon (LG102)" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="50e4-9ef3-c469-ba27" name="Tiger (MGs)" hidden="false" targetId="20a8-9287-3b20-525b" type="profile"/>
         <infoLink id="3b10-5b5f-7401-1da9" name="Tiger (8.8cm)" hidden="false" targetId="7533-54b0-a023-a8e4" type="profile"/>
@@ -4234,7 +4234,7 @@ Unit hits on 2+ &amp; Counterattacks 3+</description>
         <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="777f-a227-0a6b-c138" name="Möbelwagen AA Tank Platoon" publicationId="10a4-8008-66c3-952e" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="777f-a227-0a6b-c138" name="Möbelwagen AA Tank Platoon (LG165)" publicationId="10a4-8008-66c3-952e" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="6d10-f15a-34ec-0ef0" name="Möbelwagen (3.7cm)" hidden="false" typeId="55ec-3ef5-ca51-e647" typeName="Tank Unit">
           <characteristics>
@@ -4367,7 +4367,7 @@ Unit hits on 2+ &amp; Counterattacks 3+</description>
         <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="82b7-f19c-f147-16cd" name="Panzer III OP Observation Post " publicationId="10a4-8008-66c3-952e" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="82b7-f19c-f147-16cd" name="Panzer III OP Observation Post  (LG183)" publicationId="10a4-8008-66c3-952e" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="8273-58c8-5155-46f5" name="Panzer III OP" hidden="false" typeId="55ec-3ef5-ca51-e647" typeName="Tank Unit">
           <characteristics>
@@ -4421,7 +4421,7 @@ Unit hits on 2+ &amp; Counterattacks 3+</description>
         <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="64c1-5c6c-1f83-abe9" name="Escort Platoon" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="64c1-5c6c-1f83-abe9" name="Escort Platoon (LG241)" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="0af9-29af-dfef-cdff" name="StG44 assault rifle team" publicationId="10a4-8008-66c3-952e" hidden="false" typeId="0917-e2f0-0c3e-b482" typeName="Infantry Unit">
           <characteristics>
@@ -4554,7 +4554,7 @@ Unit hits on 2+ &amp; Counterattacks 3+</description>
         <categoryLink id="350b-1eea-ec97-16cf" name="Combat Platoons" hidden="false" targetId="5630-abd3-15d8-5cc6" primary="true"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="d0ea-08e7-84d1-2d43" name="Panzer IV/70 Tank Company HQ" publicationId="10a4-8008-66c3-952e" hidden="false" collective="false" import="true" type="unit">
+        <selectionEntry id="d0ea-08e7-84d1-2d43" name="Panzer IV/70 Tank Company HQ (LG248)" publicationId="10a4-8008-66c3-952e" hidden="false" collective="false" import="true" type="unit">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6d2a-454c-f6ba-6efd" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9f78-faec-88a4-da0c" type="max"/>
@@ -4634,7 +4634,7 @@ Unit hits on 2+ &amp; Counterattacks 3+</description>
         <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="394b-d882-333a-c4f9" name="Wirbelwind AA Tank Platoon" publicationId="10a4-8008-66c3-952e" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="394b-d882-333a-c4f9" name="Wirbelwind AA Tank Platoon (LG250)" publicationId="10a4-8008-66c3-952e" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="d711-6b7e-ca48-bc66" name="Wirbelwind" hidden="false" typeId="55ec-3ef5-ca51-e647" typeName="Tank Unit">
           <characteristics>
@@ -4699,7 +4699,7 @@ Unit hits on 2+ &amp; Counterattacks 3+</description>
         <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="2f5a-904f-0465-26cb" name="Ostwind AA Tank Platoon" publicationId="10a4-8008-66c3-952e" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="2f5a-904f-0465-26cb" name="Ostwind AA Tank Platoon (LG251)" publicationId="10a4-8008-66c3-952e" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="84a4-42e2-3407-b182" name="Ostwind (3.7cm)" hidden="false" typeId="55ec-3ef5-ca51-e647" typeName="Tank Unit">
           <characteristics>
@@ -4845,7 +4845,7 @@ Unit hits on 2+ &amp; Counterattacks 3+</description>
         <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="cf07-f1de-8b50-9501" name="SD Kfz 231 Heavy Scout Troop" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="cf07-f1de-8b50-9501" name="SD Kfz 231 Heavy Scout Troop (LG141)" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="4560-6f50-e8bf-c0e9" name="Sd Kfz 231 (5cm)" hidden="false" typeId="55ec-3ef5-ca51-e647" typeName="Tank Unit">
           <characteristics>
@@ -4904,7 +4904,7 @@ Unit hits on 2+ &amp; Counterattacks 3+</description>
         <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="5b6e-8e0a-810e-4c31" name="Hetzer Tank-Hunter Platoon" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="5b6e-8e0a-810e-4c31" name="Hetzer Tank-Hunter Platoon (LG243)" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="7ff9-6e25-d421-645d" name="Stormtroopers" hidden="false" targetId="f61c-04e9-b2cc-0d94" type="rule"/>
         <infoLink id="3922-067d-747d-9108" name="Forward Firing" hidden="false" targetId="fa9d-68f6-57d9-dc5d" type="rule"/>
@@ -4945,7 +4945,7 @@ Unit hits on 2+ &amp; Counterattacks 3+</description>
         <categoryLink id="90b9-0065-45de-4d15" name="Combat Platoons" hidden="false" targetId="5630-abd3-15d8-5cc6" primary="true"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="61c2-7bc5-e747-e8e7" name="Hetzer Tank-Hunter Company HQ" publicationId="10a4-8008-66c3-952e" hidden="false" collective="false" import="true" type="unit">
+        <selectionEntry id="61c2-7bc5-e747-e8e7" name="Hetzer Tank-Hunter Company HQ (LG242)" publicationId="10a4-8008-66c3-952e" hidden="false" collective="false" import="true" type="unit">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b2db-3119-e930-804c" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b0c1-9570-138b-1158" type="max"/>
@@ -4998,7 +4998,7 @@ Unit hits on 2+ &amp; Counterattacks 3+</description>
         <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="d440-986b-74df-6444" name="Storm Grenadier Platoon" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="d440-986b-74df-6444" name="Storm Grenadier Platoon (LG237)" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="6474-ae1c-50de-77c2" name="MG42 team" hidden="false" targetId="ba5d-12be-7472-6679" type="profile"/>
         <infoLink id="2536-0241-739b-4b38" name="MG42 team" hidden="false" targetId="046d-e8a2-fb32-e86d" type="profile"/>
@@ -5253,7 +5253,7 @@ Unit hits on 2+ &amp; Counterattacks 3+</description>
         <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="28f0-99b6-01d6-ecb8" name="JU 87 Stuka Dive Bomber Flight" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="28f0-99b6-01d6-ecb8" name="JU 87 Stuka Dive Bomber Flight (LG145)" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="2cc6-074f-1d43-b4ae" name="Bombs" hidden="false" targetId="78a2-7146-034e-a601" type="rule"/>
         <infoLink id="2ba1-d282-34e8-d685" name="Ju 87 Stuka" hidden="false" targetId="ec90-7b58-423a-b00d" type="profile"/>
@@ -5274,7 +5274,7 @@ Unit hits on 2+ &amp; Counterattacks 3+</description>
         <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="fabc-a5d1-ec02-ed0b" name="JU 87 Stuka (3.7cm) Tank-Hunger" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="fabc-a5d1-ec02-ed0b" name="JU 87 Stuka (3.7cm) Tank-Hunger (LG146)" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="4e45-d406-5f6c-78e4" name="Ju 87 Stuka" hidden="false" targetId="ec90-7b58-423a-b00d" type="profile"/>
         <infoLink id="5f67-5f32-4932-b4c1" name="Ju 87 Stuka (3.7cm)" hidden="false" targetId="b2a5-fcc6-88cf-5e00" type="profile"/>
@@ -5294,7 +5294,7 @@ Unit hits on 2+ &amp; Counterattacks 3+</description>
         <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="473f-75af-4f6f-8c07" name="Marder Tank-Hunter Platoon" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="473f-75af-4f6f-8c07" name="Marder Tank-Hunter Platoon (LG257)" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="5c21-d51a-338e-927e" name="Marder (7.5cm)" hidden="false" typeId="55ec-3ef5-ca51-e647" typeName="Tank Unit">
           <characteristics>
@@ -5369,7 +5369,7 @@ Unit hits on 2+ &amp; Counterattacks 3+</description>
         <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="4635-91da-68c6-afc4" name="Horniesse Tank-Hunter Platoon" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="4635-91da-68c6-afc4" name="Horniesse Tank-Hunter Platoon (LG129)" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="4e76-8503-2c95-0003" name="Horniesse (8.8cm)" hidden="false" typeId="55ec-3ef5-ca51-e647" typeName="Tank Unit">
           <characteristics>
@@ -5682,7 +5682,7 @@ Unit hits on 2+ &amp; Counterattacks 3+</description>
         <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="eb8f-eb29-efd6-d34b" name="Sd Kfz 250 OP Observation Post " publicationId="10a4-8008-66c3-952e" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="eb8f-eb29-efd6-d34b" name="Sd Kfz 250 OP Observation Post  (LG261)" publicationId="10a4-8008-66c3-952e" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="4210-4285-1833-a899" name="Sd Kfz 250 OP" hidden="false" typeId="55ec-3ef5-ca51-e647" typeName="Tank Unit">
           <characteristics>

--- a/LW - D-Day_American.cat
+++ b/LW - D-Day_American.cat
@@ -729,7 +729,7 @@ No range marker left after shot</description>
         <cost name="pts" typeId="995a-4d67-6920-bfe4" value="3.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="26a7-5bd1-10c4-e08d" name="P-47 Thunderbolt Fighter Flight" publicationId="567b-dc5a-c654-5ad4" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="26a7-5bd1-10c4-e08d" name="P-47 Thunderbolt Fighter Flight (LU180)" publicationId="567b-dc5a-c654-5ad4" hidden="false" collective="false" import="true" type="unit">
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d386-2e24-220e-56a2" type="max"/>
       </constraints>
@@ -1103,7 +1103,7 @@ rally 3+</description>
         <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="59c3-3306-e00a-09b2" name="M10 Tank Destroyer Platoon" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="59c3-3306-e00a-09b2" name="M10 Tank Destroyer Platoon (LU105)" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="4ae9-ad41-d12e-f7b1" name="M10" hidden="false" typeId="55ec-3ef5-ca51-e647" typeName="Tank Unit">
           <characteristics>
@@ -1377,7 +1377,7 @@ Cannot shoot or launch an assault from impassable water terrain</description>
         <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="7dcc-a935-5f5b-1862" name="M4 Sherman Tank Platoon" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="7dcc-a935-5f5b-1862" name="M4 Sherman Tank Platoon (LU101)" hidden="false" collective="false" import="true" type="unit">
       <infoLinks>
         <infoLink id="3598-fdcf-13df-c6d8" name="Smoke" hidden="false" targetId="6f51-dbfe-55b0-a6d0" type="rule"/>
         <infoLink id="bceb-be51-6398-3845" name="M4 Sherman (75mm)" hidden="false" targetId="b62f-bb5c-75ac-f852" type="profile"/>
@@ -1623,7 +1623,7 @@ Cannot shoot or launch an assault from impassable water terrain</description>
         <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="1207-02df-17fc-b369" name="Armoured M4 81mm Mortar Platoon" publicationId="567b-dc5a-c654-5ad4" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="1207-02df-17fc-b369" name="Armoured M4 81mm Mortar Platoon (LU113)" publicationId="567b-dc5a-c654-5ad4" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="6520-b4e9-19ba-331a" name="M4 (81mm mortar)" hidden="false" typeId="55ec-3ef5-ca51-e647" typeName="Tank Unit">
           <characteristics>
@@ -1673,7 +1673,7 @@ Cannot shoot or launch an assault from impassable water terrain</description>
         <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="8a49-36ac-85de-bfd1" name="M5 Stuart Tank Platoon" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="8a49-36ac-85de-bfd1" name="M5 Stuart Tank Platoon (LU103)" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="3b68-2803-ba49-cf51" name="Stabiliser" hidden="false" targetId="b7db-3fef-3b94-7c08" type="rule"/>
         <infoLink id="9e50-4f5e-c140-7a35" name="M5 Stuart" hidden="false" targetId="e03f-dadf-9c06-6785" type="profile"/>
@@ -1837,7 +1837,7 @@ Cannot shoot or launch an assault from impassable water terrain</description>
         <categoryLink id="459e-bd29-1d55-462e" name="Combat Platoons" hidden="false" targetId="5630-abd3-15d8-5cc6" primary="true"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="90f6-115c-d2d2-33fd" name="Veteran M4 Sherman Tank Company HQ" publicationId="b8e5-51cf-456c-eafb" hidden="false" collective="false" import="true" type="unit">
+        <selectionEntry id="90f6-115c-d2d2-33fd" name="Veteran M4 Sherman Tank Company HQ (LU159)" publicationId="b8e5-51cf-456c-eafb" hidden="false" collective="false" import="true" type="unit">
           <modifiers>
             <modifier type="increment" field="995a-4d67-6920-bfe4" value="1">
               <conditions>
@@ -2075,7 +2075,7 @@ Cannot shoot or launch an assault from impassable water terrain</description>
         <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="66be-f0a7-5916-49fe" name="Veteran M4 Sherman Tank Platoon" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="66be-f0a7-5916-49fe" name="Veteran M4 Sherman Tank Platoon (LU160)" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="d409-0000-7de3-6eea" name="Smoke" hidden="false" targetId="6f51-dbfe-55b0-a6d0" type="rule"/>
         <infoLink id="0791-1659-2133-22ab" name="M4 Sherman (75mm)" hidden="false" targetId="b62f-bb5c-75ac-f852" type="profile"/>
@@ -2244,7 +2244,7 @@ Cannot shoot or launch an assault from impassable water terrain</description>
         <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="6cd9-d536-c7d6-86ca" name="Veteran M5 Stuart Tank Platoon" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="6cd9-d536-c7d6-86ca" name="Veteran M5 Stuart Tank Platoon (LU164)" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="34db-8adb-3b7f-95a3" name="Stabiliser" hidden="false" targetId="b7db-3fef-3b94-7c08" type="rule"/>
         <infoLink id="ad9c-c181-bc07-21f3" name="Veteran M5 Stuart" hidden="false" targetId="82ee-93b9-711f-b859" type="profile">
@@ -2420,7 +2420,7 @@ Cannot shoot or launch an assault from impassable water terrain</description>
         <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="91d3-95fb-81c3-5ffa" name="Veteran Armoured M4 81mm Mortar Platoon" publicationId="b8e5-51cf-456c-eafb" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="91d3-95fb-81c3-5ffa" name="Veteran Armoured M4 81mm Mortar Platoon (LU171)" publicationId="b8e5-51cf-456c-eafb" hidden="false" collective="false" import="true" type="unit">
       <infoLinks>
         <infoLink id="df50-1fff-714c-438a" name="M4 (.50 cal MG)" hidden="false" targetId="8ef2-553a-61ca-a474" type="profile"/>
         <infoLink id="5f5c-381f-a145-4711" name="M4 (.50 cal MG)" hidden="false" targetId="8ef2-553a-61ca-a474" type="profile"/>
@@ -2595,7 +2595,7 @@ Unit leader does not suffer stabilizer +1 shooting penalty.</description>
         <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="60a4-7a8d-620b-2e1d" name="M8 Scott Assault Gun Platoon" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="60a4-7a8d-620b-2e1d" name="M8 Scott Assault Gun Platoon (LU158)" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="c0fa-dd22-e5a3-ebd6" name="M8 Scott (75mm)" publicationId="567b-dc5a-c654-5ad4" hidden="false" typeId="55ec-3ef5-ca51-e647" typeName="Tank Unit">
           <characteristics>
@@ -2668,7 +2668,7 @@ Unit leader does not suffer stabilizer +1 shooting penalty.</description>
         <categoryLink id="f005-9e5d-54cb-8aae" name="Combat Platoons" hidden="false" targetId="5630-abd3-15d8-5cc6" primary="true"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="9963-19c0-2b42-4f3d" name="Veteran M5 Stuart Tank Company HQ" publicationId="b8e5-51cf-456c-eafb" hidden="false" collective="false" import="true" type="unit">
+        <selectionEntry id="9963-19c0-2b42-4f3d" name="Veteran M5 Stuart Tank Company HQ (LU163)" publicationId="b8e5-51cf-456c-eafb" hidden="false" collective="false" import="true" type="unit">
           <modifiers>
             <modifier type="increment" field="995a-4d67-6920-bfe4" value="1">
               <conditions>
@@ -2878,7 +2878,7 @@ Unit leader does not suffer stabilizer +1 shooting penalty.</description>
         <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="b498-653f-4eb6-464c" name="Veteran M8 Scott Assault Gun Platoon" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="b498-653f-4eb6-464c" name="Veteran M8 Scott Assault Gun Platoon (LU170)" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="5363-5f1b-31e0-32db" name="Smoke" hidden="false" targetId="6f51-dbfe-55b0-a6d0" type="rule"/>
         <infoLink id="bb1a-cf43-6bd3-13ea" name="M8 Scott (75mm)" hidden="false" targetId="6369-e7ee-5299-e045" type="profile"/>
@@ -3750,7 +3750,7 @@ Unit leader does not suffer stabilizer +1 shooting penalty.</description>
         <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="a6a2-e58d-a90d-0479" name="Veteran Armoured Rifle Platoon" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="a6a2-e58d-a90d-0479" name="Veteran Armoured Rifle Platoon (LU167)" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="a3fd-ce2d-45f8-f140" name="Observer" hidden="false" targetId="d378-9566-3e40-0747" type="rule"/>
         <infoLink id="60a2-a810-77d9-b4fc" name="Veteran Armoured Rifleman" hidden="false" targetId="4dc5-fc73-9aaa-bb1d" type="profile">
@@ -4715,7 +4715,7 @@ Units from this formation can move freely at start of the game.  Other friendly 
         <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="2390-5c66-17d6-3b59" name="Mortar Platoon" publicationId="b8e5-51cf-456c-eafb" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="2390-5c66-17d6-3b59" name="Mortar Platoon (LU118)" publicationId="b8e5-51cf-456c-eafb" hidden="false" collective="false" import="true" type="unit">
       <infoLinks>
         <infoLink id="7ab3-bedf-307a-244a" name="Heavy Weapon" hidden="false" targetId="edf7-ad9c-029c-94fe" type="rule"/>
         <infoLink id="a511-6891-8538-f14c" name="Mortar Platoon" hidden="false" targetId="15ef-770d-9d69-9ace" type="profile">
@@ -5250,7 +5250,7 @@ Units from this formation can move freely at start of the game.  Other friendly 
         <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="9015-26ec-6f4c-a0f8" name="Veteran Mortar Platoon" publicationId="b8e5-51cf-456c-eafb" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="9015-26ec-6f4c-a0f8" name="Veteran Mortar Platoon (LU149)" publicationId="b8e5-51cf-456c-eafb" hidden="false" collective="false" import="true" type="unit">
       <infoLinks>
         <infoLink id="e025-9372-420d-9466" name="Heavy Weapon" hidden="false" targetId="edf7-ad9c-029c-94fe" type="rule"/>
         <infoLink id="5c28-a14c-4980-56a0" name="Veteran Mortar Platoon" hidden="false" targetId="3d16-c538-c630-1f91" type="profile">
@@ -5442,7 +5442,7 @@ Units from this formation can move freely at start of the game.  Other friendly 
         <cost name="pts" typeId="995a-4d67-6920-bfe4" value="6.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="8cd3-2705-45f6-1a2a" name="M15 &amp; M16 AAA Platoon" publicationId="567b-dc5a-c654-5ad4" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="8cd3-2705-45f6-1a2a" name="M15 &amp; M16 AAA Platoon (LU179)" publicationId="567b-dc5a-c654-5ad4" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="28e7-e174-181f-8e56" name="AAA Platoon" hidden="false" typeId="55ec-3ef5-ca51-e647" typeName="Tank Unit">
           <characteristics>
@@ -5552,7 +5552,7 @@ Units from this formation can move freely at start of the game.  Other friendly 
         <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="56fb-e8f2-e027-08b9" name="M7 Priest Artillery Battery" publicationId="567b-dc5a-c654-5ad4" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="56fb-e8f2-e027-08b9" name="M7 Priest Artillery Battery (LU121)" publicationId="567b-dc5a-c654-5ad4" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="61e0-b2ee-481b-322a" name="M7 Priest" hidden="false" typeId="55ec-3ef5-ca51-e647" typeName="Tank Unit">
           <characteristics>
@@ -5651,7 +5651,7 @@ Units from this formation can move freely at start of the game.  Other friendly 
         <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="fc4f-276c-a224-770f" name="105mm Field Artillery Battery" publicationId="567b-dc5a-c654-5ad4" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="fc4f-276c-a224-770f" name="105mm Field Artillery Battery (LU120)" publicationId="567b-dc5a-c654-5ad4" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="45b5-dba6-4343-919e" name="105mm howitzer" hidden="false" typeId="7c70-b6af-9e5a-e7f6" typeName="Gun Unit">
           <characteristics>
@@ -5734,7 +5734,7 @@ Units from this formation can move freely at start of the game.  Other friendly 
         <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="accd-7f6e-fe88-df86" name="M12 155mm Artillery Battery" publicationId="567b-dc5a-c654-5ad4" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="accd-7f6e-fe88-df86" name="M12 155mm Artillery Battery (LU177)" publicationId="567b-dc5a-c654-5ad4" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="fca9-76e2-28cf-97cf" name="M12 (155mm)" hidden="false" typeId="55ec-3ef5-ca51-e647" typeName="Tank Unit">
           <characteristics>
@@ -5851,7 +5851,7 @@ Can dismount when charging into contact</description>
         <cost name="pts" typeId="995a-4d67-6920-bfe4" value="1.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="f020-6b93-0f73-96c3" name="M4 Sherman OP Observation Post" publicationId="567b-dc5a-c654-5ad4" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="f020-6b93-0f73-96c3" name="M4 Sherman OP Observation Post (LU122)" publicationId="567b-dc5a-c654-5ad4" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="63be-291f-e01f-a981" name="M4 Sherman OP" publicationId="b8e5-51cf-456c-eafb" hidden="false" typeId="55ec-3ef5-ca51-e647" typeName="Tank Unit">
           <characteristics>
@@ -6212,7 +6212,7 @@ Follow Me 3+/Rally 4+</description>
         <categoryLink id="a81a-f4ac-4f30-c837" name="New CategoryLink" hidden="false" targetId="5630-abd3-15d8-5cc6" primary="true"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="b31a-62be-839c-5fd5" name="Cavalry Recon Troop HQ" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="b31a-62be-839c-5fd5" name="Cavalry Recon Troop HQ (LUCC304)" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cdae-c8a7-f018-2802" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="da79-68d9-3a68-f246" type="min"/>
@@ -6267,7 +6267,7 @@ Follow Me 3+/Rally 4+</description>
         <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="0eb7-501d-9603-49f0" name="M8 Greyhound Cavalry Recon Patrol" publicationId="567b-dc5a-c654-5ad4" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="0eb7-501d-9603-49f0" name="M8 Greyhound Cavalry Recon Patrol (LU174)" publicationId="567b-dc5a-c654-5ad4" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="8a57-d773-384d-5e3b" name="Jeep (60mm)" publicationId="b8e5-51cf-456c-eafb" hidden="false" typeId="7cf5-5c36-14cc-3c0d" typeName="Unarmoured Tank Unit">
           <characteristics>
@@ -6356,7 +6356,7 @@ Motivation Last Stand 3+</description>
         <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="2a66-aa4a-0586-b5ad" name="Assault Boat Section" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="2a66-aa4a-0586-b5ad" name="Assault Boat Section (LU138)" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="44d5-5d88-3b26-1e34" name="Assault Boat Section" hidden="false" typeId="0917-e2f0-0c3e-b482" typeName="Infantry Unit">
           <characteristics>
@@ -6470,7 +6470,7 @@ Motivation Last Stand 3+</description>
         <categoryLink id="fb30-bac5-db92-c6aa" name="Combat Platoons" hidden="false" targetId="5630-abd3-15d8-5cc6" primary="true"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="ce15-0929-3f5b-07ce" name="Assault Company HQ" publicationId="b8e5-51cf-456c-eafb" hidden="false" collective="false" import="true" type="unit">
+        <selectionEntry id="ce15-0929-3f5b-07ce" name="Assault Company HQ (LU137)" publicationId="b8e5-51cf-456c-eafb" hidden="false" collective="false" import="true" type="unit">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6a2e-3e36-15ba-c1bd" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bcfc-a9e1-b650-c994" type="max"/>
@@ -6549,7 +6549,7 @@ Motivation Last Stand 3+</description>
         <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="dfb9-1211-0837-e1d5" name="Support Boat Section" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="dfb9-1211-0837-e1d5" name="Support Boat Section (LU139)" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="9484-6d81-32c9-ac48" name="Support Boat Section" hidden="false" typeId="0917-e2f0-0c3e-b482" typeName="Infantry Unit">
           <characteristics>
@@ -6628,7 +6628,7 @@ Motivation Last Stand 3+</description>
         <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="b5f5-2aa4-dff6-47a3" name="Veteran Assault Boat Section" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="b5f5-2aa4-dff6-47a3" name="Veteran Assault Boat Section (LU144)" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="5f06-97ee-046a-7c95" name="Veteran Assault Boat" hidden="false" typeId="0917-e2f0-0c3e-b482" typeName="Infantry Unit">
           <characteristics>
@@ -6742,7 +6742,7 @@ Motivation Last Stand 3+</description>
         <categoryLink id="59b9-d3d4-922e-831c" name="Combat Platoons" hidden="false" targetId="5630-abd3-15d8-5cc6" primary="true"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="300d-5848-d0e9-e2c0" name="Veteran Assault Company HQ" publicationId="567b-dc5a-c654-5ad4" hidden="false" collective="false" import="true" type="unit">
+        <selectionEntry id="300d-5848-d0e9-e2c0" name="Veteran Assault Company HQ (LU143)" publicationId="567b-dc5a-c654-5ad4" hidden="false" collective="false" import="true" type="unit">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e83e-93c3-9c8a-1dd0" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2d0c-e0fd-af30-d3ff" type="max"/>
@@ -6821,7 +6821,7 @@ Motivation Last Stand 3+</description>
         <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="8c80-f38b-c45f-9a3f" name="Veteran Support Boat Section" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="8c80-f38b-c45f-9a3f" name="Veteran Support Boat Section (LU145)" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7240-a501-539f-56c6" type="max"/>
       </constraints>
@@ -7026,7 +7026,7 @@ Add one transport for each gun team in unit</description>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7b9e-52af-971d-8286" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="026a-c809-e223-a82f" name="Glider 75mm Artillery Battery" publicationId="b8e5-51cf-456c-eafb" hidden="false" collective="false" import="true" type="unit">
+            <selectionEntry id="026a-c809-e223-a82f" name="Glider 75mm Artillery Battery (LU133)" publicationId="b8e5-51cf-456c-eafb" hidden="false" collective="false" import="true" type="unit">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="98ae-0f36-1f8c-70a2" type="max"/>
               </constraints>
@@ -7123,7 +7123,7 @@ Add one transport for each gun team in unit</description>
         <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="24d7-74d6-49c4-973f" name="Glider Rifle Platoon" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="24d7-74d6-49c4-973f" name="Glider Rifle Platoon (LU132)" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="45bc-9982-c4a0-171f" name="Observer" hidden="false" targetId="d378-9566-3e40-0747" type="rule"/>
         <infoLink id="15cc-77d2-ae87-b71a" name="M1 Garand rifle team" hidden="false" targetId="0242-e28a-6b6f-1fbd" type="profile"/>
@@ -7180,7 +7180,7 @@ Add one transport for each gun team in unit</description>
         <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="18c6-f0aa-fc2a-fc24" name="3-inch Towed Tank Destroyer Platoon" publicationId="567b-dc5a-c654-5ad4" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="18c6-f0aa-fc2a-fc24" name="3-inch Towed Tank Destroyer Platoon (LU175)" publicationId="567b-dc5a-c654-5ad4" hidden="false" collective="false" import="true" type="unit">
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="48eb-68be-ebb3-4df6" type="max"/>
       </constraints>

--- a/LW - D-Day_British.cat
+++ b/LW - D-Day_British.cat
@@ -1814,7 +1814,7 @@ Remount 4+</description>
         <categoryLink id="cc0e-fe5f-278e-7914" name="Combat Platoons" hidden="false" targetId="5630-abd3-15d8-5cc6" primary="true"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="4c1a-6c7d-19de-89ba" name="Airlanding Company HQ" publicationId="0071-7fad-4956-579d" hidden="false" collective="false" import="true" type="unit">
+        <selectionEntry id="4c1a-6c7d-19de-89ba" name="Airlanding Company HQ (LB125)" publicationId="0071-7fad-4956-579d" hidden="false" collective="false" import="true" type="unit">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="835d-bdf4-c2e2-2cf5" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c85c-3246-5276-8c1e" type="max"/>
@@ -2677,7 +2677,7 @@ Remount 4+</description>
         <categoryLink id="86cb-63cf-2f4a-0b26" name="Combat Platoons" hidden="false" targetId="5630-abd3-15d8-5cc6" primary="true"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="0131-dc2a-9400-05dd" name="Parachute Company HQ" publicationId="0071-7fad-4956-579d" hidden="false" collective="false" import="true" type="unit">
+        <selectionEntry id="0131-dc2a-9400-05dd" name="Parachute Company HQ (LB123)" publicationId="0071-7fad-4956-579d" hidden="false" collective="false" import="true" type="unit">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="33df-8d3d-f575-189d" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="65f7-49e9-5ae7-95f2" type="max"/>
@@ -3367,7 +3367,7 @@ Rally 2+</description>
         <categoryLink id="34a4-d2b7-28e3-bdde" name="Combat Platoons" hidden="false" targetId="5630-abd3-15d8-5cc6" primary="true"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="4655-a51c-8b61-dd59" name="Commando Troop HQ" publicationId="0071-7fad-4956-579d" hidden="false" collective="false" import="true" type="unit">
+        <selectionEntry id="4655-a51c-8b61-dd59" name="Commando Troop HQ (LB132)" publicationId="0071-7fad-4956-579d" hidden="false" collective="false" import="true" type="unit">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cdfc-74e3-b32c-1a4a" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a3ae-801f-d6dd-88f0" type="max"/>
@@ -6841,7 +6841,7 @@ You may also take any 15th Scottish Division Title cards in your Force</descript
         <categoryLink id="1e7a-b8a9-8a3b-3ee4" name="Combat Platoons" hidden="false" targetId="5630-abd3-15d8-5cc6" primary="true"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="ece4-f03f-67c7-6d87" name="Desert Rat Cromwell Armoured Squadron HQ" publicationId="0071-7fad-4956-579d" hidden="false" collective="false" import="true" type="unit">
+        <selectionEntry id="ece4-f03f-67c7-6d87" name="Desert Rat Cromwell Armoured Squadron HQ (LB156)" publicationId="0071-7fad-4956-579d" hidden="false" collective="false" import="true" type="unit">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2c29-e545-3878-a55d" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1f98-9458-9d37-3da0" type="max"/>
@@ -6939,7 +6939,7 @@ You may also take any 15th Scottish Division Title cards in your Force</descript
             <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="622f-9f50-3b9c-e452" name="Desert Rat Crusader AA Troop" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="622f-9f50-3b9c-e452" name="Desert Rat Crusader AA Troop (LB159)" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed2d-7d06-61ad-f8e3" type="max"/>
           </constraints>
@@ -9637,7 +9637,7 @@ You may also take any 15th Scottish Division Title cards in your Force</descript
         <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="9fd5-3107-59e0-ee0f" name="Centaur Support Tank Platoon" publicationId="0071-7fad-4956-579d" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="9fd5-3107-59e0-ee0f" name="Centaur Support Tank Platoon (LB174)" publicationId="0071-7fad-4956-579d" hidden="false" collective="false" import="true" type="unit">
       <constraints>
         <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4055-0bc1-b79e-3871" type="max"/>
       </constraints>
@@ -9925,7 +9925,7 @@ You may also take any 15th Scottish Division Title cards in your Force</descript
         <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="9cfb-0d3f-9ed9-6d21" name="Bofors Light AA Troop" publicationId="0071-7fad-4956-579d" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="9cfb-0d3f-9ed9-6d21" name="Bofors Light AA Troop (LB120)" publicationId="0071-7fad-4956-579d" hidden="false" collective="false" import="true" type="unit">
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2b52-3072-4dd3-26e2" type="max"/>
       </constraints>
@@ -9964,7 +9964,7 @@ You may also take any 15th Scottish Division Title cards in your Force</descript
         <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="87a5-181e-0dd5-2ce6" name="Typhoon Fighter-Bomber Flight" publicationId="0071-7fad-4956-579d" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="87a5-181e-0dd5-2ce6" name="Typhoon Fighter-Bomber Flight (LB177)" publicationId="0071-7fad-4956-579d" hidden="false" collective="false" import="true" type="unit">
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c658-cad2-51da-451a" type="max"/>
       </constraints>
@@ -14990,7 +14990,7 @@ These transports are unarmed.</description>
         <cost name="pts" typeId="995a-4d67-6920-bfe4" value="1.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="963f-9efb-9aa4-c889" name="M5 Half-track Transport" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="963f-9efb-9aa4-c889" name="M5 Half-track Transport (LB199)" hidden="false" collective="false" import="true" type="upgrade">
       <rules>
         <rule id="a574-5a47-9045-bdbf" name="M5 Half-track Transport" hidden="false">
           <description>This Infantry or Gun Unit may add an M5 Half-track Transport Attachment. The number of vehicles in the Unit is as follows:

--- a/LW - Fortress Europe_America.cat
+++ b/LW - Fortress Europe_America.cat
@@ -2656,7 +2656,7 @@
         <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="44d0-a55a-bb28-2b61" name="105mm Field Artillery Battery" publicationId="b8e5-51cf-456c-eafb" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="44d0-a55a-bb28-2b61" name="105mm Field Artillery Battery (LU120)" publicationId="b8e5-51cf-456c-eafb" hidden="false" collective="false" import="true" type="unit">
       <modifierGroups>
         <modifierGroup>
           <modifiers>
@@ -2735,7 +2735,7 @@
         <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="64c0-a9a4-d01f-3f2d" name="M7 Priest Artillery Battery" publicationId="b8e5-51cf-456c-eafb" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="64c0-a9a4-d01f-3f2d" name="M7 Priest Artillery Battery (LU121)" publicationId="b8e5-51cf-456c-eafb" hidden="false" collective="false" import="true" type="unit">
       <modifierGroups>
         <modifierGroup>
           <modifiers>
@@ -2800,7 +2800,7 @@
         <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="8764-0088-73ea-e0ac" name="M4 Sherman OP Observation Post" publicationId="b8e5-51cf-456c-eafb" hidden="true" collective="false" import="true" type="unit">
+    <selectionEntry id="8764-0088-73ea-e0ac" name="M4 Sherman OP Observation Post (LU122)" publicationId="b8e5-51cf-456c-eafb" hidden="true" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="set" field="19d3-fbe3-55db-6c0d" value="1.0">
           <conditionGroups>
@@ -2856,7 +2856,7 @@
         <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="9f8b-3e5b-8a28-18d0" name="T28E1 37mm AAA Platoon" publicationId="b8e5-51cf-456c-eafb" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="9f8b-3e5b-8a28-18d0" name="T28E1 37mm AAA Platoon (LU123)" publicationId="b8e5-51cf-456c-eafb" hidden="false" collective="false" import="true" type="unit">
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="569b-12ec-1e5d-db19" type="max"/>
       </constraints>
@@ -2892,7 +2892,7 @@
         <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="0489-5be3-8be4-9c24" name="P-40 Warhawk Fighter Flight" publicationId="b8e5-51cf-456c-eafb" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="0489-5be3-8be4-9c24" name="P-40 Warhawk Fighter Flight (LU124)" publicationId="b8e5-51cf-456c-eafb" hidden="false" collective="false" import="true" type="unit">
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f781-f9ff-0eb7-1319" type="max"/>
       </constraints>

--- a/LW - Fortress Europe_British.cat
+++ b/LW - Fortress Europe_British.cat
@@ -339,7 +339,7 @@
         <categoryLink id="2654-29bd-a10f-71be" name="Combat Platoons" hidden="false" targetId="5630-abd3-15d8-5cc6" primary="true"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="7c7f-19fa-8f9f-4f23" name="Churchill Armoured Squadron HQ" publicationId="b8e5-51cf-456c-eafb" hidden="false" collective="false" import="true" type="unit">
+        <selectionEntry id="7c7f-19fa-8f9f-4f23" name="Churchill Armoured Squadron HQ (LB104)" publicationId="b8e5-51cf-456c-eafb" hidden="false" collective="false" import="true" type="unit">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7a88-5547-f064-3983" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2cc4-4f38-ed5a-f547" type="max"/>
@@ -2223,7 +2223,7 @@
         <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="217a-e9d3-542d-fee4" name="Priest Field Troop" publicationId="b8e5-51cf-456c-eafb" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="217a-e9d3-542d-fee4" name="Priest Field Troop (LB116)" publicationId="b8e5-51cf-456c-eafb" hidden="false" collective="false" import="true" type="unit">
       <modifierGroups>
         <modifierGroup>
           <modifiers>
@@ -2289,7 +2289,7 @@
         <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="2c65-b808-8adc-b71e" name="25 pdr Field Troop" publicationId="b8e5-51cf-456c-eafb" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="2c65-b808-8adc-b71e" name="25 pdr Field Troop (LB117)" publicationId="b8e5-51cf-456c-eafb" hidden="false" collective="false" import="true" type="unit">
       <modifierGroups>
         <modifierGroup>
           <modifiers>
@@ -2477,7 +2477,7 @@
         <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="5660-fbd4-8ca1-b848" name="Bofors Light AA Troop" publicationId="b8e5-51cf-456c-eafb" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="5660-fbd4-8ca1-b848" name="Bofors Light AA Troop (LB120)" publicationId="b8e5-51cf-456c-eafb" hidden="false" collective="false" import="true" type="unit">
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b156-cfff-5ffa-d22b" type="max"/>
       </constraints>
@@ -2644,7 +2644,7 @@
         <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="05e2-b9e3-ad85-a0c7" name="Kittyhawk Fighter-Bomber Flight" publicationId="b8e5-51cf-456c-eafb" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="05e2-b9e3-ad85-a0c7" name="Kittyhawk Fighter-Bomber Flight (LB121)" publicationId="b8e5-51cf-456c-eafb" hidden="false" collective="false" import="true" type="unit">
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2e53-27a6-230a-d5ff" type="max"/>
       </constraints>

--- a/LWL - American Force.cat
+++ b/LWL - American Force.cat
@@ -481,7 +481,7 @@ Work finishes 9/22/2025</readme>
     </selectionEntry>
     <selectionEntry id="3db1-12dc-ed45-6fda" name="M24 Chaffee Cavalry Recon Patrol" page="" hidden="false" collective="false" import="true" type="unit">
       <selectionEntries>
-        <selectionEntry id="76e6-652e-b12c-edd0" name="1x M24 Chaffee, 1x Jeep (MG), 1x Jeep (60mm)" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="76e6-652e-b12c-edd0" name="1x M24 Chaffee, 1x Jeep (MG), 1x Jeep (60mm) (LU618)" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1425-6ee0-ecc6-b875" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2ba7-2fe6-75c9-9b0a" type="min"/>
@@ -1093,7 +1093,7 @@ Work finishes 9/22/2025</readme>
     </selectionEntry>
     <selectionEntry id="5871-7a08-cc34-bbc3" name="Leviathan Armoured Rifle Company" hidden="false" collective="false" import="true" type="unit">
       <selectionEntries>
-        <selectionEntry id="d697-36fb-7bc6-c388" name="Leviathan Armoured Rifle Company HQ" hidden="false" collective="false" import="true" type="unit">
+        <selectionEntry id="d697-36fb-7bc6-c388" name="Leviathan Armoured Rifle Company HQ (LU203)" hidden="false" collective="false" import="true" type="unit">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="76ed-1624-4882-060f" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="1562-2239-8959-1745" type="min"/>
@@ -1511,7 +1511,7 @@ Tactics 3+</characteristic>
     </selectionEntry>
     <selectionEntry id="a35c-1db9-202c-8a56" name="[Aircraft] P-47 Thunderbolt Fighter Flight" hidden="false" collective="false" import="true" type="unit">
       <selectionEntries>
-        <selectionEntry id="4e4c-c53c-536c-40d1" name="2x P-47 Thunderbolt" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="4e4c-c53c-536c-40d1" name="2x P-47 Thunderbolt (LU180)" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0e76-6b93-4856-a013" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="80e7-f083-7f0f-39ae" type="max"/>
@@ -1528,7 +1528,7 @@ Tactics 3+</characteristic>
         <cost name="pts" typeId="995a-4d67-6920-bfe4" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="2391-b476-ed9b-d0c1" name="M4 Easy Eight OP Observation Post" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="2391-b476-ed9b-d0c1" name="M4 Easy Eight OP Observation Post (LU617)" hidden="false" collective="false" import="true" type="unit">
       <infoLinks>
         <infoLink id="37c0-7ef9-ab8d-1a29" name="M4 E8 OP" hidden="false" targetId="7c5b-42ab-d3e9-4b45" type="infoGroup"/>
       </infoLinks>
@@ -1661,7 +1661,7 @@ Tactics 3+</characteristic>
     </selectionEntry>
     <selectionEntry id="014c-47be-01bb-8783" name="Veteran Armoured 81mm Mortar Platoon" hidden="false" collective="false" import="true" type="unit">
       <selectionEntries>
-        <selectionEntry id="8e0a-19d0-ea9c-62c8" name="3x M4 (81mm mortar)" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="8e0a-19d0-ea9c-62c8" name="3x M4 (81mm mortar) (LU171)" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="bae2-43c8-ce15-f11f" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="70d7-4392-944d-c648" type="min"/>

--- a/LWL - German Force.cat
+++ b/LWL - German Force.cat
@@ -2407,7 +2407,7 @@ First edition ends 10/13/2025</readme>
     </selectionEntry>
     <selectionEntry id="9cb2-ddab-fd20-a8d3" name="Sd Kdz 250 OP Observation Post" page="" hidden="false" collective="false" import="true" type="unit">
       <selectionEntries>
-        <selectionEntry id="b488-27cb-bea6-61e9" name="1x Sd Kfz 250 OP (MG)" publicationId="3bbf-3707-35dd-b1f5" page="99" hidden="false" collective="false" import="true" type="unit">
+        <selectionEntry id="b488-27cb-bea6-61e9" name="1x Sd Kfz 250 OP (MG) (LG261)" publicationId="3bbf-3707-35dd-b1f5" page="99" hidden="false" collective="false" import="true" type="unit">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="73c6-dd1c-50b1-7cc9" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dfbe-e6e6-fb14-a7e0" type="min"/>
@@ -2460,7 +2460,7 @@ Counterattack 6</characteristic>
     </selectionEntry>
     <selectionEntry id="2de2-e591-54e6-170b" name="[Aircraft] ME 262 Fighter-Bomber Flight" page="" hidden="false" collective="false" import="true" type="unit">
       <selectionEntries>
-        <selectionEntry id="371d-9632-1918-812b" name="2x Me 262 Sturmvogel" publicationId="3bbf-3707-35dd-b1f5" page="101" hidden="false" collective="false" import="true" type="unit">
+        <selectionEntry id="371d-9632-1918-812b" name="2x Me 262 Sturmvogel (LG449)" publicationId="3bbf-3707-35dd-b1f5" page="101" hidden="false" collective="false" import="true" type="unit">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c99d-d435-a83f-175b" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8c85-20a9-1e5d-cd86" type="min"/>


### PR DESCRIPTION
## What
Adds the official Flames of War force-diagram unit codes (e.g. `LG102`, `LU174`) to the
`name` of unit entries across 7 Late-War catalogues, following the existing `(LGxxx)`
convention already used in about half the catalogues (D-Day German, Bulge German, etc.).

## Why
Makes units cross-referenceable with the forces.flamesofwar.com force diagrams and any
tooling that joins on those codes. Roughly half the LW books already carry them; this fills
gaps in books that don't.

## Scope
92 codes across: Bagration German, D-Day American, D-Day British, Fortress Europe
America/British, LWL American/German. **Only names changed** — no stats, weapons, points, or
structure touched (each change is just ` (CODE)` appended to a `name`).

## How each code was verified
Every code was matched by the unit's full stat fingerprint — Motivation / Skill / Is Hit On /
Save-or-Armour / Movement plus each weapon's Range / ROF / Anti-Tank / Firepower — against the
published stats, not by name alone. Only exact, unambiguous stat matches with a corroborating
name and correct era/nation code prefix were included, and codes were checked for 1:1
uniqueness within each book. Ambiguous cases were intentionally left out, so this is a
conservative, high-confidence set.